### PR TITLE
Detect OSV degenerate tag matches via canary query

### DIFF
--- a/lib/brew/vulns/osv_client.rb
+++ b/lib/brew/vulns/osv_client.rb
@@ -15,6 +15,13 @@ module Brew
       MAX_RETRIES = 3
       RETRY_DELAY = 1
 
+      # Sent alongside each real query. OSV's normalize_tag extracts digit-runs;
+      # digit-free strings collapse to "" and fuzzy-match any digit-free tag in
+      # an affected range (e.g. "last-cvs-commit"). If real and canary return
+      # identical non-empty sets, the real tag hit the same degenerate match.
+      # See issue #41 and google/osv.dev gcp/api/server.py:_match_versions.
+      CANARY_VERSION = "brew-vulns-canary"
+
       class Error < StandardError; end
       class ApiError < Error; end
 
@@ -37,24 +44,36 @@ module Brew
         return [] if packages.empty?
 
         results = Array.new(packages.size) { [] }
+        # Each package costs two query slots (real + canary).
+        slice_size = BATCH_SIZE / 2
 
-        packages.each_slice(BATCH_SIZE).with_index do |batch, batch_idx|
-          queries = batch.map do |pkg|
-            {
-              package: {
-                name: pkg[:repo_url],
-                ecosystem: "GIT"
-              },
-              version: pkg[:version]
-            }
+        packages.each_slice(slice_size).with_index do |batch, batch_idx|
+          queries = []
+          batch.each do |pkg|
+            package_ref = { name: pkg[:repo_url], ecosystem: "GIT" }
+            queries << { package: package_ref, version: pkg[:version] }
+            queries << { package: package_ref, version: CANARY_VERSION }
           end
 
           response = post("/querybatch", { queries: queries })
           batch_results = response["results"] || []
 
-          batch_results.each_with_index do |result, idx|
-            global_idx = batch_idx * BATCH_SIZE + idx
-            results[global_idx] = result["vulns"] || []
+          batch.each_with_index do |pkg, idx|
+            global_idx = batch_idx * slice_size + idx
+            real   = batch_results[idx * 2]     || {}
+            canary = batch_results[idx * 2 + 1] || {}
+
+            real_ids   = (real["vulns"]   || []).map { |v| v["id"] }.sort
+            canary_ids = (canary["vulns"] || []).map { |v| v["id"] }.sort
+
+            if !canary_ids.empty? && real_ids == canary_ids
+              warn "Warning: OSV could not resolve #{pkg[:name] || pkg[:repo_url]} " \
+                   "tag #{pkg[:version].inspect}; skipping (results matched " \
+                   "default-branch fallback)"
+              results[global_idx] = []
+            else
+              results[global_idx] = real["vulns"] || []
+            end
           end
         end
 

--- a/lib/brew/vulns/osv_client.rb
+++ b/lib/brew/vulns/osv_client.rb
@@ -44,15 +44,23 @@ module Brew
         return [] if packages.empty?
 
         results = Array.new(packages.size) { [] }
-        # Each package costs two query slots (real + canary).
+        # Worst case every version is digit-free and gets a canary, so slice at
+        # half the limit to guarantee queries.size <= BATCH_SIZE.
         slice_size = BATCH_SIZE / 2
 
         packages.each_slice(slice_size).with_index do |batch, batch_idx|
           queries = []
+          offsets = []
           batch.each do |pkg|
             package_ref = { name: pkg[:repo_url], ecosystem: "GIT" }
+            real_idx = queries.size
             queries << { package: package_ref, version: pkg[:version] }
-            queries << { package: package_ref, version: CANARY_VERSION }
+            canary_idx = nil
+            unless pkg[:version].to_s.match?(/\d/)
+              canary_idx = queries.size
+              queries << { package: package_ref, version: CANARY_VERSION }
+            end
+            offsets << [real_idx, canary_idx]
           end
 
           response = post("/querybatch", { queries: queries })
@@ -60,20 +68,20 @@ module Brew
 
           batch.each_with_index do |pkg, idx|
             global_idx = batch_idx * slice_size + idx
-            real   = batch_results[idx * 2]     || {}
-            canary = batch_results[idx * 2 + 1] || {}
+            real_idx, canary_idx = offsets[idx]
+            real = batch_results[real_idx] || {}
+            results[global_idx] = real["vulns"] || []
+            next unless canary_idx
 
-            real_ids   = (real["vulns"]   || []).map { |v| v["id"] }.sort
+            canary = batch_results[canary_idx] || {}
+            real_ids   = results[global_idx].map { |v| v["id"] }.sort
             canary_ids = (canary["vulns"] || []).map { |v| v["id"] }.sort
+            next if canary_ids.empty? || real_ids != canary_ids
 
-            if !canary_ids.empty? && real_ids == canary_ids
-              warn "Warning: OSV could not resolve #{pkg[:name] || pkg[:repo_url]} " \
-                   "tag #{pkg[:version].inspect}; skipping (results matched " \
-                   "default-branch fallback)"
-              results[global_idx] = []
-            else
-              results[global_idx] = real["vulns"] || []
-            end
+            warn "Warning: OSV could not resolve #{pkg[:name] || pkg[:repo_url]} " \
+                 "tag #{pkg[:version].inspect}; skipping (results matched " \
+                 "default-branch fallback)"
+            results[global_idx] = []
           end
         end
 

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -685,4 +685,170 @@ class TestCLI < Minitest::Test
            "More than #{Brew::Vulns::CLI::MAX_VULN_FETCH_THREADS} threads " \
            "were running concurrently: #{max_threads}"
   end
+
+  # Regression guard for issue #41.
+  # When OSV's GIT-ecosystem tag resolution lags behind a new release, the
+  # batch endpoint can return CVEs from years ago. The local affects_version?
+  # filter at cli.rb:128 is the safety net. This test simulates OSV
+  # over-returning and verifies only the vuln whose explicit versions list
+  # contains the installed tag survives.
+  def test_local_filter_drops_legacy_cves_when_osv_over_returns
+    icu_data = {
+      "name" => "icu4c@78",
+      "versions" => { "stable" => "78.3" },
+      "urls" => {
+        "stable" => {
+          "url" => "https://github.com/unicode-org/icu/releases/download/release-78.3/icu4c-78.3-sources.tgz"
+        }
+      }
+    }
+    formulae = [Brew::Vulns::Formula.new(icu_data)]
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [{
+          vulns: [
+            { "id" => "CVE-2016-6293" },
+            { "id" => "CVE-2017-14952" },
+            { "id" => "OSV-2023-1328" }
+          ]
+        }]
+      }.to_json)
+
+    # Old CVE: versions list contains only release-57-1, GIT range only.
+    stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2016-6293")
+      .to_return(status: 200, body: {
+        "id" => "CVE-2016-6293",
+        "summary" => "Stack-based buffer overflow",
+        "database_specific" => { "severity" => "CRITICAL" },
+        "affected" => [{
+          "versions" => ["release-57-1"],
+          "ranges" => [{
+            "type" => "GIT",
+            "events" => [
+              { "introduced" => "0" },
+              { "last_affected" => "0c5873f89bf64f6bbc0a24b84f07d79b25785a42" }
+            ]
+          }]
+        }]
+      }.to_json)
+
+    # Another old CVE: hyphenated old releases only.
+    stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2017-14952")
+      .to_return(status: 200, body: {
+        "id" => "CVE-2017-14952",
+        "summary" => "Double free",
+        "database_specific" => { "severity" => "CRITICAL" },
+        "affected" => [{
+          "versions" => ["release-58-1", "release-58-2", "release-59-1", "release-59-rc"],
+          "ranges" => [{
+            "type" => "GIT",
+            "events" => [{ "introduced" => "0" }, { "fixed" => "abc123" }]
+          }]
+        }]
+      }.to_json)
+
+    # Current vuln: versions list explicitly names release-78.3.
+    stub_request(:get, "https://api.osv.dev/v1/vulns/OSV-2023-1328")
+      .to_return(status: 200, body: {
+        "id" => "OSV-2023-1328",
+        "summary" => "Stack-buffer-overflow in TZDBTimeZoneNames",
+        "affected" => [{
+          "package" => { "name" => "icu", "ecosystem" => "OSS-Fuzz" },
+          "ecosystem_specific" => { "severity" => "HIGH" },
+          "versions" => ["release-77-1", "release-78.1", "release-78.2", "release-78.3"],
+          "ranges" => [{
+            "type" => "GIT",
+            "events" => [{ "introduced" => "5cf5ec1adbd2332b3cc289b5b1f5ca8324275fc3" }]
+          }]
+        }]
+      }.to_json)
+
+    output = Brew::Vulns::Formula.stub :load_installed, formulae do
+      capture_stdout { Brew::Vulns::CLI.run(["--json"]) }
+    end
+
+    json = JSON.parse(output)
+
+    assert_equal 1, json.size
+    assert_equal "icu4c@78", json[0]["formula"]
+    ids = json[0]["vulnerabilities"].map { |v| v["id"] }
+    assert_equal ["OSV-2023-1328"], ids
+    refute_includes ids, "CVE-2016-6293"
+    refute_includes ids, "CVE-2017-14952"
+  end
+
+  # The query payload sent to OSV must always carry a non-empty version.
+  # An empty or null version makes OSV return every vuln ever filed against
+  # the repo. This test asserts the batch request body never contains
+  # version: "" or version: null for any formula that passed the pre-filter.
+  def test_batch_query_never_sends_empty_version
+    formulae = [
+      Brew::Vulns::Formula.new(@vim_data),
+      Brew::Vulns::Formula.new(@curl_data)
+    ]
+
+    captured_body = nil
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .with { |req| captured_body = JSON.parse(req.body) }
+      .to_return(status: 200, body: { results: [{}, {}, {}, {}] }.to_json)
+
+    Brew::Vulns::Formula.stub :load_installed, formulae do
+      Brew::Vulns::CLI.run([])
+    end
+
+    refute_nil captured_body
+    queries = captured_body["queries"]
+    # Two formulae × (real + canary) = four queries. Real queries sit at
+    # even indices.
+    assert_equal 4, queries.size
+    real_queries = queries.each_slice(2).map(&:first)
+    real_queries.each do |q|
+      refute_nil q["version"], "query #{q.inspect} sent nil version"
+      refute_empty q["version"], "query #{q.inspect} sent empty version"
+      refute_equal Brew::Vulns::OsvClient::CANARY_VERSION, q["version"]
+    end
+  end
+
+  # Results must be attributed to the right formula by index. If anything
+  # between map(&:to_osv_query) and results lookup ever shifts indices,
+  # vim's vulns would land on curl. This test puts a distinctive vuln ID at
+  # each batch position and checks each comes back attached to the formula
+  # that sent that query.
+  def test_batch_results_align_with_formulae
+    formulae = [
+      Brew::Vulns::Formula.new(@vim_data),
+      Brew::Vulns::Formula.new(@curl_data)
+    ]
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [
+          { vulns: [{ "id" => "VULN-FOR-VIM" }] }, {},
+          { vulns: [{ "id" => "VULN-FOR-CURL" }] }, {}
+        ]
+      }.to_json)
+
+    stub_request(:get, "https://api.osv.dev/v1/vulns/VULN-FOR-VIM")
+      .to_return(status: 200, body: {
+        "id" => "VULN-FOR-VIM",
+        "database_specific" => { "severity" => "HIGH" }
+      }.to_json)
+
+    stub_request(:get, "https://api.osv.dev/v1/vulns/VULN-FOR-CURL")
+      .to_return(status: 200, body: {
+        "id" => "VULN-FOR-CURL",
+        "database_specific" => { "severity" => "HIGH" }
+      }.to_json)
+
+    output = Brew::Vulns::Formula.stub :load_installed, formulae do
+      capture_stdout { Brew::Vulns::CLI.run(["--json"]) }
+    end
+
+    json = JSON.parse(output)
+    by_formula = json.to_h { |entry| [entry["formula"], entry["vulnerabilities"].map { |v| v["id"] }] }
+
+    assert_equal ["VULN-FOR-VIM"], by_formula["vim"]
+    assert_equal ["VULN-FOR-CURL"], by_formula["curl"]
+  end
 end

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -791,7 +791,7 @@ class TestCLI < Minitest::Test
     captured_body = nil
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .with { |req| captured_body = JSON.parse(req.body) }
-      .to_return(status: 200, body: { results: [{}, {}, {}, {}] }.to_json)
+      .to_return(status: 200, body: { results: [{}, {}] }.to_json)
 
     Brew::Vulns::Formula.stub :load_installed, formulae do
       Brew::Vulns::CLI.run([])
@@ -799,11 +799,9 @@ class TestCLI < Minitest::Test
 
     refute_nil captured_body
     queries = captured_body["queries"]
-    # Two formulae × (real + canary) = four queries. Real queries sit at
-    # even indices.
-    assert_equal 4, queries.size
-    real_queries = queries.each_slice(2).map(&:first)
-    real_queries.each do |q|
+    # Two formulae with digit-bearing versions = two queries, no canaries.
+    assert_equal 2, queries.size
+    queries.each do |q|
       refute_nil q["version"], "query #{q.inspect} sent nil version"
       refute_empty q["version"], "query #{q.inspect} sent empty version"
       refute_equal Brew::Vulns::OsvClient::CANARY_VERSION, q["version"]
@@ -824,8 +822,8 @@ class TestCLI < Minitest::Test
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .to_return(status: 200, body: {
         results: [
-          { vulns: [{ "id" => "VULN-FOR-VIM" }] }, {},
-          { vulns: [{ "id" => "VULN-FOR-CURL" }] }, {}
+          { vulns: [{ "id" => "VULN-FOR-VIM" }] },
+          { vulns: [{ "id" => "VULN-FOR-CURL" }] }
         ]
       }.to_json)
 

--- a/test/brew/test_osv_client.rb
+++ b/test/brew/test_osv_client.rb
@@ -51,14 +51,18 @@ class TestOsvClient < Minitest::Test
   end
 
   def test_query_batch_returns_results_for_each_package
+    # Response order is [real0, canary0, real1, canary1, real2, canary2].
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .to_return(
         status: 200,
         body: {
           results: [
             { vulns: [{ id: "CVE-2024-1111" }] },
+            {},
             { vulns: [] },
-            { vulns: [{ id: "CVE-2024-2222" }, { id: "CVE-2024-3333" }] }
+            {},
+            { vulns: [{ id: "CVE-2024-2222" }, { id: "CVE-2024-3333" }] },
+            {}
           ]
         }.to_json
       )
@@ -80,6 +84,212 @@ class TestOsvClient < Minitest::Test
   def test_query_batch_returns_empty_array_for_empty_input
     results = @client.query_batch([])
     assert_equal [], results
+  end
+
+  def test_query_batch_interleaves_canary_queries
+    captured = nil
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .with { |req| captured = JSON.parse(req.body) }
+      .to_return(status: 200, body: { results: [{}, {}, {}, {}] }.to_json)
+
+    packages = [
+      { repo_url: "https://github.com/a/a", version: "v1.0" },
+      { repo_url: "https://github.com/b/b", version: "v2.0" }
+    ]
+    @client.query_batch(packages)
+
+    queries = captured["queries"]
+    assert_equal 4, queries.size
+    assert_equal "v1.0", queries[0]["version"]
+    assert_equal Brew::Vulns::OsvClient::CANARY_VERSION, queries[1]["version"]
+    assert_equal "v2.0", queries[2]["version"]
+    assert_equal Brew::Vulns::OsvClient::CANARY_VERSION, queries[3]["version"]
+    assert_equal "https://github.com/a/a", queries[0]["package"]["name"]
+    assert_equal "https://github.com/a/a", queries[1]["package"]["name"]
+    assert_equal "https://github.com/b/b", queries[2]["package"]["name"]
+    assert_equal "https://github.com/b/b", queries[3]["package"]["name"]
+  end
+
+  def test_query_batch_skips_when_real_matches_canary
+    # Identical non-empty result sets at real and canary positions means OSV
+    # resolved both to the same fallback. The package should come back empty.
+    fallback = [{ id: "CVE-2017-1111" }, { id: "CVE-2017-2222" }]
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [
+          { vulns: fallback },
+          { vulns: fallback }
+        ]
+      }.to_json)
+
+    packages = [{ repo_url: "https://github.com/a/a", version: "v9.9.9", name: "a" }]
+
+    err = capture_stderr { @results = @client.query_batch(packages) }
+
+    assert_equal [[]], @results
+    assert_match(/OSV could not resolve a tag "v9.9.9"/, err)
+  end
+
+  def test_query_batch_keeps_results_when_real_differs_from_canary
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [
+          { vulns: [{ id: "OSV-2023-1328" }] },
+          { vulns: [{ id: "CVE-2017-1111" }, { id: "CVE-2017-2222" }] }
+        ]
+      }.to_json)
+
+    packages = [{ repo_url: "https://github.com/a/a", version: "release-78.3", name: "icu" }]
+
+    err = capture_stderr { @results = @client.query_batch(packages) }
+
+    assert_equal 1, @results[0].size
+    assert_equal "OSV-2023-1328", @results[0][0]["id"]
+    assert_empty err
+  end
+
+  def test_query_batch_keeps_results_when_canary_is_empty
+    # An empty canary tells us nothing. Even if real is also empty, that is
+    # the normal "no vulns" case, not a fallback signal.
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [
+          { vulns: [{ id: "CVE-2024-1234" }] },
+          {}
+        ]
+      }.to_json)
+
+    packages = [{ repo_url: "https://github.com/a/a", version: "v1.0", name: "a" }]
+    results = @client.query_batch(packages)
+
+    assert_equal 1, results[0].size
+  end
+
+  def test_query_batch_compares_id_sets_not_order
+    # OSV does not guarantee result order. Sort before comparing.
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [
+          { vulns: [{ id: "CVE-A" }, { id: "CVE-B" }] },
+          { vulns: [{ id: "CVE-B" }, { id: "CVE-A" }] }
+        ]
+      }.to_json)
+
+    packages = [{ repo_url: "https://github.com/a/a", version: "v1.0", name: "a" }]
+    results = @client.query_batch(packages)
+
+    assert_equal [], results[0]
+  end
+
+  def test_query_batch_canary_only_affects_matching_package
+    # Three packages: middle one hits the fallback, the others are fine.
+    fallback = [{ id: "CVE-2017-1111" }]
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [
+          { vulns: [{ id: "CVE-2024-AAAA" }] }, {},
+          { vulns: fallback }, { vulns: fallback },
+          { vulns: [{ id: "CVE-2024-CCCC" }] }, {}
+        ]
+      }.to_json)
+
+    packages = [
+      { repo_url: "https://github.com/a/a", version: "v1", name: "a" },
+      { repo_url: "https://github.com/b/b", version: "v2", name: "b" },
+      { repo_url: "https://github.com/c/c", version: "v3", name: "c" }
+    ]
+    results = @client.query_batch(packages)
+
+    assert_equal 1, results[0].size
+    assert_equal "CVE-2024-AAAA", results[0][0]["id"]
+    assert_equal [], results[1]
+    assert_equal 1, results[2].size
+    assert_equal "CVE-2024-CCCC", results[2][0]["id"]
+  end
+
+  # The canary must contain no decimal digit. OSV's normalize_tag regex
+  # (\d+|(?<![a-z])(rc|alpha|beta|preview)\d*) extracts nothing from a
+  # digit-free string, yielding "". That "" then equals the normalized form
+  # of any digit-free tag in a CVE's affected list (e.g. "last-cvs-commit",
+  # "latest"). A single 0-9 anywhere produces a non-empty normalization and
+  # the degenerate match is avoided. ("deadbeef" matches; "deadbeef0" does not.)
+  def test_canary_version_has_no_decimal_digits
+    refute_match(/[0-9]/, Brew::Vulns::OsvClient::CANARY_VERSION)
+  end
+
+  def test_query_batch_slices_at_500_packages
+    slice_size = Brew::Vulns::OsvClient::BATCH_SIZE / 2
+    total = slice_size + 3
+
+    packages = Array.new(total) do |i|
+      { repo_url: "https://github.com/x/p#{i}", version: "v#{i}", name: "p#{i}" }
+    end
+
+    captured = []
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return do |req|
+        body = JSON.parse(req.body)
+        captured << body["queries"]
+        # Tag each real-slot result with its position in this request so we
+        # can verify global index assignment after the batches are merged.
+        results = body["queries"].each_with_index.map do |q, i|
+          if q["version"] == Brew::Vulns::OsvClient::CANARY_VERSION
+            {}
+          else
+            { vulns: [{ id: "REQ#{captured.size - 1}-Q#{i}" }] }
+          end
+        end
+        { status: 200, body: { results: results }.to_json }
+      end
+
+    results = @client.query_batch(packages)
+
+    assert_equal 2, captured.size
+    assert_equal slice_size * 2, captured[0].size
+    assert_equal 6, captured[1].size
+
+    assert_equal total, results.size
+
+    # First package of batch 0 sits at request 0, query slot 0.
+    assert_equal "REQ0-Q0", results[0][0]["id"]
+    # Last package of batch 0 sits at request 0, query slot 998 (499 * 2).
+    assert_equal "REQ0-Q#{(slice_size - 1) * 2}", results[slice_size - 1][0]["id"]
+    # First package of batch 1 sits at request 1, query slot 0.
+    assert_equal "REQ1-Q0", results[slice_size][0]["id"]
+    # Last package overall sits at request 1, query slot 4 (2 * 2).
+    assert_equal "REQ1-Q4", results[total - 1][0]["id"]
+
+    # No off-by-one gaps anywhere in the merged results.
+    refute results.any?(&:empty?)
+  end
+
+  def test_query_batch_canary_detection_works_in_second_slice
+    slice_size = Brew::Vulns::OsvClient::BATCH_SIZE / 2
+
+    packages = Array.new(slice_size + 1) do |i|
+      { repo_url: "https://github.com/x/p#{i}", version: "v#{i}", name: "p#{i}" }
+    end
+
+    fallback = [{ id: "CVE-OLD" }]
+    call = 0
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return do |req|
+        call += 1
+        n = JSON.parse(req.body)["queries"].size
+        if call == 1
+          { status: 200, body: { results: Array.new(n) { {} } }.to_json }
+        else
+          # Second request has one package: real and canary both get the
+          # fallback set.
+          { status: 200, body: { results: [{ vulns: fallback }, { vulns: fallback }] }.to_json }
+        end
+      end
+
+    err = capture_stderr { @results = @client.query_batch(packages) }
+
+    assert_equal slice_size + 1, @results.size
+    assert_equal [], @results[slice_size]
+    assert_match(/p#{slice_size}/, err)
   end
 
   def test_raises_api_error_on_http_error

--- a/test/brew/test_osv_client.rb
+++ b/test/brew/test_osv_client.rb
@@ -51,18 +51,14 @@ class TestOsvClient < Minitest::Test
   end
 
   def test_query_batch_returns_results_for_each_package
-    # Response order is [real0, canary0, real1, canary1, real2, canary2].
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .to_return(
         status: 200,
         body: {
           results: [
             { vulns: [{ id: "CVE-2024-1111" }] },
-            {},
             { vulns: [] },
-            {},
-            { vulns: [{ id: "CVE-2024-2222" }, { id: "CVE-2024-3333" }] },
-            {}
+            { vulns: [{ id: "CVE-2024-2222" }, { id: "CVE-2024-3333" }] }
           ]
         }.to_json
       )
@@ -86,28 +82,27 @@ class TestOsvClient < Minitest::Test
     assert_equal [], results
   end
 
-  def test_query_batch_interleaves_canary_queries
+  def test_query_batch_adds_canary_only_for_digit_free_versions
     captured = nil
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .with { |req| captured = JSON.parse(req.body) }
-      .to_return(status: 200, body: { results: [{}, {}, {}, {}] }.to_json)
+      .to_return(status: 200, body: { results: [{}, {}, {}] }.to_json)
 
     packages = [
       { repo_url: "https://github.com/a/a", version: "v1.0" },
-      { repo_url: "https://github.com/b/b", version: "v2.0" }
+      { repo_url: "https://github.com/b/b", version: "HEAD" }
     ]
     @client.query_batch(packages)
 
+    # Only the digit-free version gets a paired canary query.
     queries = captured["queries"]
-    assert_equal 4, queries.size
+    assert_equal 3, queries.size
     assert_equal "v1.0", queries[0]["version"]
-    assert_equal Brew::Vulns::OsvClient::CANARY_VERSION, queries[1]["version"]
-    assert_equal "v2.0", queries[2]["version"]
-    assert_equal Brew::Vulns::OsvClient::CANARY_VERSION, queries[3]["version"]
+    assert_equal "HEAD", queries[1]["version"]
+    assert_equal Brew::Vulns::OsvClient::CANARY_VERSION, queries[2]["version"]
     assert_equal "https://github.com/a/a", queries[0]["package"]["name"]
-    assert_equal "https://github.com/a/a", queries[1]["package"]["name"]
+    assert_equal "https://github.com/b/b", queries[1]["package"]["name"]
     assert_equal "https://github.com/b/b", queries[2]["package"]["name"]
-    assert_equal "https://github.com/b/b", queries[3]["package"]["name"]
   end
 
   def test_query_batch_skips_when_real_matches_canary
@@ -122,12 +117,32 @@ class TestOsvClient < Minitest::Test
         ]
       }.to_json)
 
-    packages = [{ repo_url: "https://github.com/a/a", version: "v9.9.9", name: "a" }]
+    packages = [{ repo_url: "https://github.com/a/a", version: "HEAD", name: "a" }]
 
     err = capture_stderr { @results = @client.query_batch(packages) }
 
     assert_equal [[]], @results
-    assert_match(/OSV could not resolve a tag "v9.9.9"/, err)
+    assert_match(/OSV could not resolve a tag "HEAD"/, err)
+  end
+
+  def test_query_batch_never_skips_digit_bearing_version
+    # A vuln with introduced:0 and no fix affects every commit. If we sent a
+    # canary for a normal digit-bearing version, real and canary would match
+    # and we'd wrongly suppress it. Digit-bearing versions must not be gated.
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [{ vulns: [{ id: "CVE-2024-OPEN" }] }]
+      }.to_json)
+
+    packages = [{ repo_url: "https://github.com/a/a", version: "v9.9.9", name: "a" }]
+
+    err = capture_stderr { @results = @client.query_batch(packages) }
+
+    assert_equal "CVE-2024-OPEN", @results[0][0]["id"]
+    assert_empty err
+    assert_requested(:post, "https://api.osv.dev/v1/querybatch") do |req|
+      JSON.parse(req.body)["queries"].size == 1
+    end
   end
 
   def test_query_batch_keeps_results_when_real_differs_from_canary
@@ -139,7 +154,7 @@ class TestOsvClient < Minitest::Test
         ]
       }.to_json)
 
-    packages = [{ repo_url: "https://github.com/a/a", version: "release-78.3", name: "icu" }]
+    packages = [{ repo_url: "https://github.com/a/a", version: "main", name: "icu" }]
 
     err = capture_stderr { @results = @client.query_batch(packages) }
 
@@ -159,7 +174,7 @@ class TestOsvClient < Minitest::Test
         ]
       }.to_json)
 
-    packages = [{ repo_url: "https://github.com/a/a", version: "v1.0", name: "a" }]
+    packages = [{ repo_url: "https://github.com/a/a", version: "main", name: "a" }]
     results = @client.query_batch(packages)
 
     assert_equal 1, results[0].size
@@ -175,27 +190,28 @@ class TestOsvClient < Minitest::Test
         ]
       }.to_json)
 
-    packages = [{ repo_url: "https://github.com/a/a", version: "v1.0", name: "a" }]
+    packages = [{ repo_url: "https://github.com/a/a", version: "main", name: "a" }]
     results = @client.query_batch(packages)
 
     assert_equal [], results[0]
   end
 
   def test_query_batch_canary_only_affects_matching_package
-    # Three packages: middle one hits the fallback, the others are fine.
+    # Three packages: middle one is digit-free and hits the fallback, the
+    # others have normal versions and are not canary-checked.
     fallback = [{ id: "CVE-2017-1111" }]
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .to_return(status: 200, body: {
         results: [
-          { vulns: [{ id: "CVE-2024-AAAA" }] }, {},
+          { vulns: [{ id: "CVE-2024-AAAA" }] },
           { vulns: fallback }, { vulns: fallback },
-          { vulns: [{ id: "CVE-2024-CCCC" }] }, {}
+          { vulns: [{ id: "CVE-2024-CCCC" }] }
         ]
       }.to_json)
 
     packages = [
       { repo_url: "https://github.com/a/a", version: "v1", name: "a" },
-      { repo_url: "https://github.com/b/b", version: "v2", name: "b" },
+      { repo_url: "https://github.com/b/b", version: "HEAD", name: "b" },
       { repo_url: "https://github.com/c/c", version: "v3", name: "c" }
     ]
     results = @client.query_batch(packages)
@@ -244,20 +260,21 @@ class TestOsvClient < Minitest::Test
 
     results = @client.query_batch(packages)
 
+    # All versions contain digits, so no canaries are sent.
     assert_equal 2, captured.size
-    assert_equal slice_size * 2, captured[0].size
-    assert_equal 6, captured[1].size
+    assert_equal slice_size, captured[0].size
+    assert_equal 3, captured[1].size
 
     assert_equal total, results.size
 
     # First package of batch 0 sits at request 0, query slot 0.
     assert_equal "REQ0-Q0", results[0][0]["id"]
-    # Last package of batch 0 sits at request 0, query slot 998 (499 * 2).
-    assert_equal "REQ0-Q#{(slice_size - 1) * 2}", results[slice_size - 1][0]["id"]
+    # Last package of batch 0 sits at request 0, query slot 499.
+    assert_equal "REQ0-Q#{slice_size - 1}", results[slice_size - 1][0]["id"]
     # First package of batch 1 sits at request 1, query slot 0.
     assert_equal "REQ1-Q0", results[slice_size][0]["id"]
-    # Last package overall sits at request 1, query slot 4 (2 * 2).
-    assert_equal "REQ1-Q4", results[total - 1][0]["id"]
+    # Last package overall sits at request 1, query slot 2.
+    assert_equal "REQ1-Q2", results[total - 1][0]["id"]
 
     # No off-by-one gaps anywhere in the merged results.
     refute results.any?(&:empty?)
@@ -269,6 +286,7 @@ class TestOsvClient < Minitest::Test
     packages = Array.new(slice_size + 1) do |i|
       { repo_url: "https://github.com/x/p#{i}", version: "v#{i}", name: "p#{i}" }
     end
+    packages[slice_size][:version] = "HEAD"
 
     fallback = [{ id: "CVE-OLD" }]
     call = 0
@@ -279,8 +297,8 @@ class TestOsvClient < Minitest::Test
         if call == 1
           { status: 200, body: { results: Array.new(n) { {} } }.to_json }
         else
-          # Second request has one package: real and canary both get the
-          # fallback set.
+          # Second request has one digit-free package: real and canary both
+          # get the fallback set.
           { status: 200, body: { results: [{ vulns: fallback }, { vulns: fallback }] }.to_json }
         end
       end

--- a/test/brew/test_vulnerability.rb
+++ b/test/brew/test_vulnerability.rb
@@ -435,4 +435,83 @@ class TestVulnerability < Minitest::Test
     assert vuln.affects_version?("1.5.0")
     refute vuln.affects_version?("1.5.1")
   end
+
+  # Regression guard for issue #41.
+  # Real-shaped OSV record from CVE-2016-6293 (icu): a single GIT range with
+  # last_affected as a commit SHA, plus an explicit versions list naming only
+  # the old release. A current tag like release-78.3 must not match.
+  def test_affects_version_rejects_legacy_cve_with_git_range_and_old_versions_list
+    data = {
+      "id" => "CVE-2016-6293",
+      "affected" => [
+        {
+          "versions" => ["release-57-1"],
+          "ranges" => [
+            {
+              "type" => "GIT",
+              "repo" => "https://github.com/unicode-org/icu",
+              "events" => [
+                { "introduced" => "0" },
+                { "last_affected" => "0c5873f89bf64f6bbc0a24b84f07d79b25785a42" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    refute vuln.affects_version?("release-78.3")
+    refute vuln.affects_version?("release-77-1")
+    assert vuln.affects_version?("release-57-1")
+  end
+
+  # Regression guard for issue #41.
+  # Real-shaped OSV record from OSV-2023-1328 (icu OSS-Fuzz finding): GIT range
+  # with introduced-only events plus a long explicit versions list. A tag that
+  # appears in the list must match; one that does not must be rejected.
+  def test_affects_version_matches_only_listed_release_tags
+    data = {
+      "id" => "OSV-2023-1328",
+      "affected" => [
+        {
+          "package" => { "name" => "icu", "ecosystem" => "OSS-Fuzz" },
+          "versions" => [
+            "release-75-rc", "release-75-1", "release-76-1", "release-76-rc",
+            "release-77-rc", "release-77-1", "release-78.1", "release-78.2",
+            "release-78.3"
+          ],
+          "ranges" => [
+            {
+              "type" => "GIT",
+              "events" => [
+                { "introduced" => "5cf5ec1adbd2332b3cc289b5b1f5ca8324275fc3" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert vuln.affects_version?("release-78.3")
+    assert vuln.affects_version?("release-75-1")
+    refute vuln.affects_version?("release-74-1")
+    refute vuln.affects_version?("release-79-1")
+  end
+
+  # The two icu records above use different separators in the same field:
+  # release-57-1 (hyphen) vs release-78.3 (dot). normalize_version only strips
+  # a leading "v" so these stay distinct. If someone adds smarter normalization
+  # later, this test catches accidental over-matching.
+  def test_affects_version_does_not_normalize_hyphen_dot_separators
+    data = {
+      "id" => "TEST-1",
+      "affected" => [{ "versions" => ["release-78-3"] }]
+    }
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert vuln.affects_version?("release-78-3")
+    refute vuln.affects_version?("release-78.3")
+  end
 end


### PR DESCRIPTION
Investigating #41 turned up a permanent OSV quirk: `normalize_tag` collapses any string with no decimal digit to `""`, which then fuzzy-matches any digit-free tag sitting in a CVE's affected-versions list. The icu repo has tags like `last-cvs-commit` and `latest`, so querying for `"deadbeef"` returns seven 2017-era CVEs while `"deadbeef0"` returns zero. Filed upstream as google/osv.dev#5230.

This PR sends a digit-free canary version alongside each real query in the batch. If real and canary return identical non-empty result sets, OSV did not meaningfully resolve the real tag — skip that formula with a stderr warning instead of reporting whatever the degenerate match produced. Cost is doubling the query count inside the same HTTP request; batch slicing now cuts at 500 packages instead of 1000.

Also adds regression tests for the local `affects_version?` filter using real-shaped icu CVE records (CVE-2016-6293, OSV-2023-1328), batch index alignment, and slicing at the 500-package boundary.

The reporter's specific #41 case appears to have been transient bad data from google/osv.dev#5103 — every flagged CVE was re-indexed in the days after that PR landed. The canary doesn't defend against bad upstream `affected.versions` content, but the local-filter regression tests pin what we can verify.