### PR TITLE
feat: set User-Agent header on OSV API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Set User-Agent header on OSV API requests (#49)
+
 ## [0.2.2] - 2026-01-25
 
 - Add retry logic to OSV API requests (up to 3 attempts on timeout or connection errors)

--- a/lib/brew/vulns/osv_client.rb
+++ b/lib/brew/vulns/osv_client.rb
@@ -3,6 +3,7 @@
 require "net/http"
 require "json"
 require "uri"
+require "brew/vulns/version"
 
 module Brew
   module Vulns
@@ -16,6 +17,8 @@ module Brew
 
       class Error < StandardError; end
       class ApiError < Error; end
+
+      USER_AGENT = "brew-vulns/#{Brew::Vulns::VERSION} (+https://github.com/Homebrew/homebrew-brew-vulns)"
 
       def query(repo_url:, version:)
         payload = {
@@ -66,6 +69,7 @@ module Brew
         uri = URI("#{API_BASE}#{path}")
         request = Net::HTTP::Post.new(uri)
         request["Content-Type"] = "application/json"
+        request["User-Agent"] = USER_AGENT
         request.body = JSON.generate(payload)
 
         execute_request(uri, request)
@@ -75,6 +79,7 @@ module Brew
         uri = URI("#{API_BASE}#{path}")
         request = Net::HTTP::Get.new(uri)
         request["Content-Type"] = "application/json"
+        request["User-Agent"] = USER_AGENT
 
         execute_request(uri, request)
       end

--- a/test/brew/test_osv_client.rb
+++ b/test/brew/test_osv_client.rb
@@ -36,6 +36,20 @@ class TestOsvClient < Minitest::Test
     assert_equal [], vulns
   end
 
+  def test_sets_user_agent_header
+    stub_request(:post, "https://api.osv.dev/v1/query")
+      .with(
+        headers: {
+          "User-Agent" => %r{\Abrew-vulns/\d+\.\d+\.\d+ \(\+https://github\.com/Homebrew/homebrew-brew-vulns\)\z}
+        }
+      )
+      .to_return(status: 200, body: { vulns: [] }.to_json)
+
+    @client.query(repo_url: "https://github.com/test/repo", version: "v1.0.0")
+
+    assert_requested :post, "https://api.osv.dev/v1/query"
+  end
+
   def test_query_batch_returns_results_for_each_package
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .to_return(


### PR DESCRIPTION
## Summary

Set a `User-Agent` header on all outgoing OSV API requests so the OSV team can identify `brew-vulns` traffic.

Fixes #49.

## Why this matters

Maintainer andrew filed #49 on 2026-04-13 noting that requests from `lib/brew/vulns/osv_client.rb:67-68` currently send no `User-Agent`. `Net::HTTP` falls back to a generic `Ruby` UA, which makes it hard for the OSV team to reach out about traffic patterns or rate limits. The issue suggests `brew-vulns/#{VERSION} (+https://github.com/Homebrew/homebrew-brew-vulns)` — matching what this change implements.

Both `post(path, payload)` (used for `/query` and `/querybatch`) and `get(path)` (used for `/vulns/:id`) go through the same pair of lines that already set `Content-Type`, so the header is attached in both places.

## Changes

- `lib/brew/vulns/osv_client.rb`: require `brew/vulns/version`, define `USER_AGENT` constant on `OsvClient`, set `request["User-Agent"] = USER_AGENT` in both `post` and `get`.
- `test/brew/test_osv_client.rb`: add `test_sets_user_agent_header` that uses WebMock's header matcher with a regex asserting the `brew-vulns/X.Y.Z (+URL)` shape.
- `CHANGELOG.md`: add entry under `[Unreleased]`.

## Testing

CI will run the full suite. Local test run was not possible from the contribution environment (system Ruby 2.6 lacks `simplecov`, and `bundler 4.0.6` is not installed locally), but the diff is three minimal additions and the new test is modeled on the existing `test_query_returns_vulnerabilities` style with a WebMock header matcher.

---

This contribution was developed with AI assistance (Codex).