### PR TITLE
OsvClient: cap fetch_all_pages at MAX_PAGES to avoid unbounded loop

### DIFF
--- a/lib/brew/vulns/osv_client.rb
+++ b/lib/brew/vulns/osv_client.rb
@@ -117,15 +117,24 @@ module Brew
         end
       end
 
+      MAX_PAGES = 100
+
       def fetch_all_pages(response, original_payload)
         vulns = response["vulns"] || []
         page_token = response["next_page_token"]
+        page_count = 1
 
         while page_token
+          if page_count >= MAX_PAGES
+            raise ApiError,
+                  "OSV API returned more than #{MAX_PAGES} pages of results; aborting to avoid an unbounded loop"
+          end
+
           payload = original_payload.merge(page_token: page_token)
           response = post("/query", payload)
           vulns.concat(response["vulns"] || [])
           page_token = response["next_page_token"]
+          page_count += 1
         end
 
         vulns

--- a/test/brew/test_osv_client.rb
+++ b/test/brew/test_osv_client.rb
@@ -91,6 +91,21 @@ class TestOsvClient < Minitest::Test
     assert_equal "CVE-2", vulns[1]["id"]
   end
 
+  def test_pagination_aborts_after_max_pages
+    # Server keeps echoing a page token forever — without an upper bound the
+    # client would loop until it OOMs. Verify it raises a clear ApiError instead.
+    stub_request(:post, "https://api.osv.dev/v1/query")
+      .to_return(
+        { status: 200, body: { vulns: [{ id: "CVE-LOOP" }], next_page_token: "infinite" }.to_json }
+      )
+
+    error = assert_raises(Brew::Vulns::OsvClient::ApiError) do
+      @client.query(repo_url: "https://github.com/test/repo", version: "v1.0.0")
+    end
+
+    assert_match(/more than \d+ pages/, error.message)
+  end
+
   def test_get_vulnerability_returns_full_data
     stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2024-1234")
       .to_return(


### PR DESCRIPTION
Closes #47.

`OsvClient#fetch_all_pages` (`lib/brew/vulns/osv_client.rb:120`) loops as long as the OSV response carries a `next_page_token`, with no upper bound:

```ruby
while page_token
  payload = original_payload.merge(page_token: page_token)
  response = post("/query", payload)
  vulns.concat(response["vulns"] || [])
  page_token = response["next_page_token"]
end
```

If the upstream returns a buggy response that echoes the same `next_page_token` (or unconditionally returns one), the loop concatenates into `vulns` until the process OOM-kills.

Add a `MAX_PAGES = 100` ceiling and raise `ApiError` with a clear message when the limit is hit, turning the infinite-pagination case into an actionable error. Added a regression test (`test_pagination_aborts_after_max_pages`) that stubs the server to return the same token forever and asserts the `ApiError`.

**Local verification:** Ruby `-c` syntax check passes for both files. I couldn't run `bundle exec rake test` locally because system Ruby is 2.6 and `Gemfile.lock` pins `bundler 4.0.6` which requires Ruby >= 3.2 — happy to iterate on the test if CI catches anything.