### PR TITLE
Cap concurrent requests when fetching vulnerability details

### DIFF
--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -9,6 +9,7 @@ module Brew
 
       DEFAULT_MAX_SUMMARY = 60
       SEVERITY_LEVELS = { "low" => 1, "medium" => 2, "high" => 3, "critical" => 4 }.freeze
+      MAX_VULN_FETCH_THREADS = 15
 
       def initialize(args)
         @args = args
@@ -118,10 +119,13 @@ module Brew
           batch_vulns = vuln_results[idx] || []
           next if batch_vulns.empty?
 
-          threads = batch_vulns.map do |v|
-            Thread.new { client.get_vulnerability(v["id"]) }
+          full_vulns = batch_vulns.each_slice(MAX_VULN_FETCH_THREADS).flat_map do |slice|
+            threads = slice.map do |v|
+              Thread.new { client.get_vulnerability(v["id"]) }
+            end
+            threads.map(&:value)
           end
-          full_vulns = threads.map(&:value)
+
           vulns = Vulnerability.from_osv_list(full_vulns)
 
           version = formula.tag || formula.version

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -649,4 +649,40 @@ class TestCLI < Minitest::Test
     assert sbom["components"].any? { |c| c["name"] == "vim" }
     assert_empty sbom["vulnerabilities"] || []
   end
+
+  def test_scan_vulnerabilities_limits_active_threads
+    formulae = [Brew::Vulns::Formula.new(@vim_data)]
+    fake_cves = Array.new(50) { |i| { "id" => "CVE-#{i}" } }
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: { results: [{ vulns: fake_cves }] }.to_json)
+    fake_cves.each do |cve|
+      stub_request(:get, "https://api.osv.dev/v1/vulns/#{cve["id"]}")
+        .to_return(status: 200, body: { "id" => cve["id"], "summary" => "Test vulnerability" }
+        .to_json)
+    end
+
+    max_threads = 0
+    current_threads = 0
+    # stub thread creation to track how many threads are active at the same time
+    Thread.stub(:new, proc { |*args, **kwargs, &block|
+      current_threads += 1
+      max_threads = [max_threads, current_threads].max
+      Thread.start do
+        begin
+          block.call(*args, **kwargs)
+        ensure
+          current_threads -= 1
+        end
+      end
+    }) do
+      Brew::Vulns::Formula.stub :load_installed, formulae do
+        Brew::Vulns::CLI.run([])
+      end
+    end
+
+    assert max_threads <= Brew::Vulns::CLI::MAX_VULN_FETCH_THREADS,
+           "More than #{Brew::Vulns::CLI::MAX_VULN_FETCH_THREADS} threads " \
+           "were running concurrently: #{max_threads}"
+  end
 end


### PR DESCRIPTION
### Summary

Addresses #46. Packages with N vulnerabilities will open N `https` connections to `api.osv.dev`. This can lead to file descriptor exhaustion or trigger rate limiting from the OSV API.

This PR addresses the problem by batching requests into groups of 15, waiting for each batch to complete before spawning the next group. The limit of 15 concurrent requests was chosen conservatively. This constant could be adjusted to balance performance and resource usage.

Thread pool solution was not implemented at this time. The current approach allows to solve the problem simply, while not requiring any additional dependencies. I would be happy to re-iterate, however, if needed.

### Testing Notes

- `bundle exec rake test` tests pass ✅.
- Observed the amount of open file descriptors (via `/proc/self`) to be within an acceptable range, when simulating an API response with ~300 vulnerabilities.
- Unit test was added to verify amount of active threads is within acceptable range when fetching vulnerability details.