### PR TITLE
Fix SimpleCov not initializing before test runs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,9 @@ require "minitest/test_task"
 require "digest"
 require "open-uri"
 
-Minitest::TestTask.create
+Minitest::TestTask.create do |t|
+  t.framework = %(require "test/test_helper.rb")
+end
 
 task default: :test
 


### PR DESCRIPTION
Before this PR's changes, it can be observed that `SimpleCov` generates the coverage report before tests are executed, resulting in incorrect coverage data.

This PR overrides `Minitest` default initialization order to load `test_helper.rb` first. This forces `SimpleCov` to start before test runs.

Related issues: https://github.com/minitest/minitest/issues/1020, https://github.com/simplecov-ruby/simplecov/issues/1032.