### PR TITLE
Implement severity band computation based on CVSS vector string

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     brew-vulns (0.2.3)
+      cvss-suite (~> 4.1)
       purl (~> 1.6)
       sarif-ruby (~> 0.1)
       sbom (~> 0.4)
@@ -16,6 +17,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
+    cvss-suite (4.1.0)
     date (3.5.1)
     docile (1.4.1)
     drb (2.2.3)
@@ -94,6 +96,7 @@ CHECKSUMS
   bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
   brew-vulns (0.2.3)
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
+  cvss-suite (4.1.0) sha256=156590c22bb3ccebbc6be270b516759780264ab2b838b4ac2ecd3ee47712c8be
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/brew-vulns.gemspec
+++ b/brew-vulns.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = ["brew-vulns"]
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "cvss-suite", "~> 4.1"
   spec.add_dependency "purl", "~> 1.6"
   spec.add_dependency "sarif-ruby", "~> 0.1"
   spec.add_dependency "sbom", "~> 0.4"

--- a/lib/brew/vulns/vulnerability.rb
+++ b/lib/brew/vulns/vulnerability.rb
@@ -2,6 +2,7 @@
 
 require "purl"
 require "vers"
+require "cvss_suite"
 
 module Brew
   module Vulns
@@ -77,7 +78,7 @@ module Brew
       def extract_severity(data)
         if data["severity"]&.any?
           sev = data["severity"].first
-          if sev["score"]&.include?("CVSS")
+          if sev["type"]&.include?("CVSS")
             return severity_from_cvss(sev["score"])
           end
         end
@@ -109,34 +110,15 @@ module Brew
       end
 
       def severity_from_cvss(vector)
-        return nil unless vector
-        return nil unless vector.include?("CVSS:3")
+        return nil if vector.to_s.empty?
 
-        metrics = parse_cvss_metrics(vector)
-        return nil if metrics.empty?
+        cvss = CvssSuite.new(vector)
 
-        impact_high = %w[C I A].count { |m| metrics[m] == "H" }
-        network_attack = metrics["AV"] == "N"
-        no_privs = metrics["PR"] == "N"
-        no_interaction = metrics["UI"] == "N"
-
-        if impact_high >= 2 && network_attack && no_privs
-          "critical"
-        elsif impact_high >= 1 && network_attack
-          "high"
-        elsif impact_high >= 1 || (network_attack && no_privs && no_interaction)
-          "medium"
-        else
-          "low"
-        end
-      end
-
-      def parse_cvss_metrics(vector)
-        metrics = {}
-        vector.scan(%r{([A-Z]+):([A-Z])}).each do |key, value|
-          metrics[key] = value
-        end
-        metrics
+        normalize_severity(cvss.severity)
+      rescue StandardError
+        warn "Warning: Failed to determine severity from CVSS vector " \
+             "'#{vector}' for '#{id}'"
+        nil
       end
 
       def normalize_version(version)

--- a/test/brew/test_vulnerability.rb
+++ b/test/brew/test_vulnerability.rb
@@ -35,7 +35,7 @@ class TestVulnerability < Minitest::Test
   def test_extracts_severity_from_cvss_high
     data = {
       "id" => "CVE-2024-1234",
-      "severity" => [{ "type" => "CVSS_V3", "score" => "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N" }]
+      "severity" => [{ "type" => "CVSS_V3", "score" => "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H" }]
     }
 
     vuln = Brew::Vulns::Vulnerability.new(data)
@@ -66,6 +66,82 @@ class TestVulnerability < Minitest::Test
 
     assert_equal "LOW", vuln.severity_display
     assert_equal 1, vuln.severity_level
+  end
+
+  def test_extracts_severity_from_cvss_v2
+    data = {
+      "id" => "CVE-2026-1234",
+      "severity" => [{ "type" => "CVSS_V2",
+                       "score" => "AV:N/AC:L/Au:N/C:P/I:P/A:P" }]
+    }
+
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert_equal "HIGH", vuln.severity_display
+    assert_equal 3, vuln.severity_level
+  end
+
+  def test_extracts_severity_from_cvss_v3
+    data = {
+      "id" => "CVE-2026-1234",
+      "severity" => [{ "type" => "CVSS_V3",
+                       "score" => "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" }]
+    }
+
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert_equal "CRITICAL", vuln.severity_display
+    assert_equal 4, vuln.severity_level
+  end
+
+  def test_extracts_severity_from_cvss_v4
+    data = {
+      "id" => "CVE-2026-1234",
+      "severity" => [{ "type" => "CVSS_V4",
+                       "score" => "CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N" }]
+    }
+
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert_equal "MEDIUM", vuln.severity_display
+    assert_equal 2, vuln.severity_level
+  end
+
+  def test_extracts_severity_unknown_from_cvss_none
+    data = {
+      "id" => "CVE-2026-1234",
+      "severity" => [{ "type" => "CVSS_V4",
+                       "score" => "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N" }]
+    }
+
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert_equal "UNKNOWN", vuln.severity_display
+    assert_equal 0, vuln.severity_level
+  end
+
+  def test_extracts_severity_from_invalid_cvss_vector
+    data = {
+      "id" => "CVE-2024-0003",
+      "severity" => [{ "type" => "CVSS_V3", "score" => "INVALID-CVSS" }]
+    }
+
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert_equal "UNKNOWN", vuln.severity_display
+    assert_equal 0, vuln.severity_level
+  end
+
+  def test_extracts_severity_from_empty_cvss_vector
+    data = {
+      "id" => "CVE-2024-0003",
+      "severity" => [{ "type" => "CVSS_V3", "score" => "" }]
+    }
+
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert_equal "UNKNOWN", vuln.severity_display
+    assert_equal 0, vuln.severity_level
   end
 
   def test_extracts_severity_from_database_specific


### PR DESCRIPTION
### Summary
Addresses #48. Previously, `severity_from_cvss` method counted high-impact metrics and checked AV/PR/UI rather than computing the CVSS base score. This commit utilizes `cvss-suite` gem and computes the severity based on the CVSS vector.

### Additional Changes
- Add support for CVSS version 2, 3 and 4 as per [OSV API](https://ossf.github.io/osv-schema/#severitytype-field). Please note that this PR removes an [explicit check](https://github.com/Homebrew/homebrew-brew-vulns/blob/main/lib/brew/vulns/vulnerability.rb#L113) that would only compute severity based on CVSS_V3 scores.
- `None` severity will now be normalized to `Unknown`. This change could be considered controversial. The rationale is that OSV API should not contain any entries that resolve to `NONE` according to CVSS scoring, however if such an entry is encountered, the probability of such CVSS scoring being a mistake should be high.
### Testing Notes
- Added unit tests to verify severity extraction from CVSS v2, v3 and v4.
- Added unit tests to verify behavior under invalid or empty CVSS vector. (Please note that OSV API [schema](https://github.com/ossf/osv-schema/blob/main/validation/schema.json) should not allow empty or invalid vector string).
- Added unit test to verify extraction of `NONE` severity from a CVSS score.
- More comprehensive fuzz testing for CVSS parsing was not implemented as a part of this PR at this time due to the relative simplicity of the fix.