### PR TITLE
fix(scanner): fail closed when range check raises

### DIFF
--- a/lib/brew/vulns/vulnerability.rb
+++ b/lib/brew/vulns/vulnerability.rb
@@ -159,7 +159,7 @@ module Brew
         Vers.satisfies?(version, constraints.join(","), ecosystem)
       rescue StandardError => e
         warn "Warning: Failed to check version '#{version}' against constraints: #{e.message}"
-        false
+        true
       end
 
       def build_constraints(events)

--- a/test/brew/test_vulnerability.rb
+++ b/test/brew/test_vulnerability.rb
@@ -435,4 +435,29 @@ class TestVulnerability < Minitest::Test
     assert vuln.affects_version?("1.5.0")
     refute vuln.affects_version?("1.5.1")
   end
+
+  def test_affects_version_fails_closed_when_range_check_raises
+    data = {
+      "id" => "CVE-2024-1234",
+      "affected" => [
+        {
+          "ranges" => [
+            {
+              "type" => "SEMVER",
+              "events" => [
+                { "introduced" => "1.0.0" },
+                { "fixed" => "1.5.0" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    Vers.stub :satisfies?, ->(*) { raise StandardError, "boom" } do
+      assert vuln.affects_version?("1.2.0"),
+             "version_in_range? must fail closed (return true) when range check raises"
+    end
+  end
 end


### PR DESCRIPTION
## What

`version_in_range?` rescues `StandardError` and returns `false` when `Vers.satisfies?` raises. This makes `affects_version?` treat the vuln as not matching, so the finding is filtered out at cli.rb:128 and the user never sees it. The warning goes to stderr, which is silent under `--json`, `--sarif`, and `--cyclonedx`.

This change returns `true` on rescue so a parse failure surfaces the vuln rather than hiding it.

## Why

`affects_version?` already uses this convention at line 61: when `affected` is empty (no data), it returns `true`. That's the safer default for a scanner: when in doubt, include the finding so the user can triage a false positive, rather than silently dropping a potential real one.

## Test plan

- [x] Added a regression test that stubs `Vers.satisfies?` to raise and asserts `affects_version?` returns `true`.
- [x] Ruby syntax check on both files.
- [ ] CI matrix runs on Ruby 3.4 and 4.0.

Closes #44