### PR TITLE
Fix unbounded introduced-zero OSV ranges

### DIFF
--- a/lib/brew/vulns/vulnerability.rb
+++ b/lib/brew/vulns/vulnerability.rb
@@ -154,7 +154,7 @@ module Brew
         return false if events.nil? || events.empty?
 
         constraints = build_constraints(events)
-        return true if affects_all_versions?(events)
+        return true if constraints.empty? && introduced_from_beginning?(events)
         return false if constraints.empty?
 
         Vers.satisfies?(version, constraints.join(","), ecosystem)
@@ -176,13 +176,18 @@ module Brew
           if event["last_affected"]
             constraints << "<=#{normalize_version(event["last_affected"])}"
           end
+          if event["limit"] && !event["limit"].include?("*")
+            constraints << "<#{normalize_version(event["limit"])}"
+          end
         end
         constraints
       end
 
-      def affects_all_versions?(events)
-        events.any? { |event| event["introduced"] == "0" } &&
-          events.none? { |event| event["fixed"] || event["last_affected"] || event["limit"] }
+      def introduced_from_beginning?(events)
+        events.any? do |event|
+          introduced = event["introduced"]
+          introduced && normalize_version(introduced) == "0"
+        end
       end
     end
   end

--- a/lib/brew/vulns/vulnerability.rb
+++ b/lib/brew/vulns/vulnerability.rb
@@ -153,41 +153,53 @@ module Brew
       def version_in_range?(version, events, ecosystem)
         return false if events.nil? || events.empty?
 
-        constraints = build_constraints(events)
-        return true if constraints.empty? && introduced_from_beginning?(events)
-        return false if constraints.empty?
-
-        Vers.satisfies?(version, constraints.join(","), ecosystem)
+        build_constraint_sets(events).any? do |constraints|
+          constraints.empty? || Vers.satisfies?(version, constraints.join(","), ecosystem)
+        end
       rescue StandardError => e
         warn "Warning: Failed to check version '#{version}' against constraints: #{e.message}"
         false
       end
 
-      def build_constraints(events)
-        constraints = []
+      def build_constraint_sets(events)
+        constraint_sets = []
+        constraints = nil
+
         events.each do |event|
           if event["introduced"]
+            constraints = []
             intro = normalize_version(event["introduced"])
             constraints << ">=#{intro}" unless intro == "0"
-          end
-          if event["fixed"]
+          elsif event["fixed"]
+            constraints ||= []
             constraints << "<#{normalize_version(event["fixed"])}"
-          end
-          if event["last_affected"]
+            constraint_sets << constraints
+            constraints = nil
+          elsif event["last_affected"]
+            constraints ||= []
             constraints << "<=#{normalize_version(event["last_affected"])}"
-          end
-          if event["limit"] && !event["limit"].include?("*")
-            constraints << "<#{normalize_version(event["limit"])}"
+            constraint_sets << constraints
+            constraints = nil
+          elsif event.key?("limit")
+            constraints ||= []
+            limit_constraint = build_limit_constraint(event["limit"])
+            constraints << limit_constraint if limit_constraint
+            constraint_sets << constraints
+            constraints = nil
           end
         end
-        constraints
+
+        constraint_sets << constraints if constraints
+        constraint_sets
       end
 
-      def introduced_from_beginning?(events)
-        events.any? do |event|
-          introduced = event["introduced"]
-          introduced && normalize_version(introduced) == "0"
-        end
+      def build_limit_constraint(limit)
+        return if limit.nil?
+
+        limit = limit.to_s
+        return if limit.include?("*")
+
+        "<#{normalize_version(limit)}"
       end
     end
   end

--- a/lib/brew/vulns/vulnerability.rb
+++ b/lib/brew/vulns/vulnerability.rb
@@ -180,7 +180,7 @@ module Brew
             constraints << "<=#{normalize_version(event["last_affected"])}"
             constraint_sets << constraints
             constraints = nil
-          elsif event.key?("limit")
+          elsif event["limit"]
             constraints ||= []
             limit_constraint = build_limit_constraint(event["limit"])
             constraints << limit_constraint if limit_constraint
@@ -194,10 +194,8 @@ module Brew
       end
 
       def build_limit_constraint(limit)
-        return if limit.nil?
-
         limit = limit.to_s
-        return if limit.include?("*")
+        return if limit == "*"
 
         "<#{normalize_version(limit)}"
       end

--- a/lib/brew/vulns/vulnerability.rb
+++ b/lib/brew/vulns/vulnerability.rb
@@ -154,6 +154,7 @@ module Brew
         return false if events.nil? || events.empty?
 
         constraints = build_constraints(events)
+        return true if affects_all_versions?(events)
         return false if constraints.empty?
 
         Vers.satisfies?(version, constraints.join(","), ecosystem)
@@ -177,6 +178,11 @@ module Brew
           end
         end
         constraints
+      end
+
+      def affects_all_versions?(events)
+        events.any? { |event| event["introduced"] == "0" } &&
+          events.none? { |event| event["fixed"] || event["last_affected"] || event["limit"] }
       end
     end
   end

--- a/test/brew/test_vulnerability.rb
+++ b/test/brew/test_vulnerability.rb
@@ -365,6 +365,28 @@ class TestVulnerability < Minitest::Test
     refute vuln.affects_version?("0.9.0")
   end
 
+  def test_affects_version_matches_introduced_zero_without_fix
+    data = {
+      "id" => "CVE-2024-1234",
+      "affected" => [
+        {
+          "ranges" => [
+            {
+              "type" => "SEMVER",
+              "events" => [
+                { "introduced" => "0" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert vuln.affects_version?("0.1.0")
+    assert vuln.affects_version?("1.2.3")
+  end
+
   def test_affects_version_ignores_git_ranges
     data = {
       "id" => "CVE-2024-1234",

--- a/test/brew/test_vulnerability.rb
+++ b/test/brew/test_vulnerability.rb
@@ -387,6 +387,50 @@ class TestVulnerability < Minitest::Test
     assert vuln.affects_version?("1.2.3")
   end
 
+  def test_affects_version_matches_prefixed_introduced_zero_without_fix
+    data = {
+      "id" => "CVE-2024-1234",
+      "affected" => [
+        {
+          "ranges" => [
+            {
+              "type" => "SEMVER",
+              "events" => [
+                { "introduced" => "v0" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert vuln.affects_version?("1.2.3")
+  end
+
+  def test_affects_version_handles_limit_ranges
+    data = {
+      "id" => "CVE-2024-1234",
+      "affected" => [
+        {
+          "ranges" => [
+            {
+              "type" => "SEMVER",
+              "events" => [
+                { "introduced" => "0" },
+                { "limit" => "2.0.0" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert vuln.affects_version?("1.9.9")
+    refute vuln.affects_version?("2.0.0")
+  end
+
   def test_affects_version_ignores_git_ranges
     data = {
       "id" => "CVE-2024-1234",

--- a/test/brew/test_vulnerability.rb
+++ b/test/brew/test_vulnerability.rb
@@ -431,6 +431,57 @@ class TestVulnerability < Minitest::Test
     refute vuln.affects_version?("2.0.0")
   end
 
+  def test_affects_version_handles_wildcard_limit_ranges
+    data = {
+      "id" => "CVE-2024-1234",
+      "affected" => [
+        {
+          "ranges" => [
+            {
+              "type" => "SEMVER",
+              "events" => [
+                { "introduced" => "1.0.0" },
+                { "limit" => "*" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert vuln.affects_version?("1.0.0")
+    assert vuln.affects_version?("9.9.9")
+    refute vuln.affects_version?("0.9.9")
+  end
+
+  def test_affects_version_handles_multiple_semver_intervals
+    data = {
+      "id" => "CVE-2024-1234",
+      "affected" => [
+        {
+          "ranges" => [
+            {
+              "type" => "SEMVER",
+              "events" => [
+                { "introduced" => "0" },
+                { "limit" => "2.0.0" },
+                { "introduced" => "3.0.0" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert vuln.affects_version?("1.9.9")
+    refute vuln.affects_version?("2.0.0")
+    refute vuln.affects_version?("2.9.9")
+    assert vuln.affects_version?("3.0.0")
+    assert vuln.affects_version?("4.0.0")
+  end
+
   def test_affects_version_ignores_git_ranges
     data = {
       "id" => "CVE-2024-1234",


### PR DESCRIPTION
## Summary

Fixes handling for OSV SEMVER ranges that only contain `introduced: "0"` with no `fixed` or `last_affected` event.

According to the OSV schema, this represents an unfixed vulnerability affecting all versions. Previously, `build_constraints` skipped `introduced: "0"`, which produced an empty constraint list and
caused `version_in_range?` to return `false`.

Fixes #64.

## Testing

- `bundle exec ruby -Itest test/brew/test_vulnerability.rb`
- `bundle exec rake test`