### PR TITLE
Sanitize terminal escapes in text output

### DIFF
--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -318,11 +318,11 @@ module Brew
 
       def sanitize_terminal_escapes(text)
         text.to_s
-          .gsub(/\e\][^\a]*(?:\a|\e\\)/, "")
-          .gsub(/\u009d[^\a]*(?:\a|\u009c)/, "")
+          .gsub(/\e\][^\a\e]*(?:\a|\e\\)/, "")
+          .gsub(/\u009d[^\a\u009c]*(?:\a|\u009c)/, "")
           .gsub(/\u009b[0-?]*[ -\/]*[@-~]/, "")
           .gsub(/\e\[[0-?]*[ -\/]*[@-~]/, "")
-          .delete("\e\u0080-\u009f")
+          .delete("\e\b\r\u0007\u0080-\u009f")
       end
 
       def colorize_severity(severity)

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -287,12 +287,12 @@ module Brew
         sorted = results.sort_by { |_, vulns| -vulns.map(&:severity_level).max }
 
         sorted.each do |formula, vulns|
-          puts "#{formula.name} (#{formula.version})"
+          puts "#{sanitize_terminal_escapes(formula.name)} (#{sanitize_terminal_escapes(formula.version)})"
           vulns.sort_by { |v| -v.severity_level }.each do |vuln|
             total_vulns += 1
             severity = colorize_severity(vuln.severity_display)
 
-            line = "  #{vuln.id} (#{severity})"
+            line = "  #{sanitize_terminal_escapes(vuln.id)} (#{severity})"
             if vuln.summary
               sanitized_summary = sanitize_terminal_escapes(vuln.summary)
               summary = if @max_summary > 0 && sanitized_summary.length > @max_summary
@@ -305,7 +305,8 @@ module Brew
             puts line
 
             if vuln.fixed_versions.any?
-              puts "    Fixed in: #{vuln.fixed_versions.join(", ")}"
+              fixed_versions = vuln.fixed_versions.map { |version| sanitize_terminal_escapes(version) }
+              puts "    Fixed in: #{fixed_versions.join(", ")}"
             end
           end
           puts
@@ -316,10 +317,12 @@ module Brew
       end
 
       def sanitize_terminal_escapes(text)
-        text
+        text.to_s
           .gsub(/\e\][^\a]*(?:\a|\e\\)/, "")
+          .gsub(/\u009d[^\a]*(?:\a|\u009c)/, "")
+          .gsub(/\u009b[0-?]*[ -\/]*[@-~]/, "")
           .gsub(/\e\[[0-?]*[ -\/]*[@-~]/, "")
-          .delete("\e")
+          .delete("\e\u0080-\u009f")
       end
 
       def colorize_severity(severity)

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -294,10 +294,11 @@ module Brew
 
             line = "  #{vuln.id} (#{severity})"
             if vuln.summary
-              summary = if @max_summary > 0 && vuln.summary.length > @max_summary
-                "#{vuln.summary.slice(0, @max_summary)}..."
+              sanitized_summary = sanitize_terminal_escapes(vuln.summary)
+              summary = if @max_summary > 0 && sanitized_summary.length > @max_summary
+                "#{sanitized_summary.slice(0, @max_summary)}..."
               else
-                vuln.summary
+                sanitized_summary
               end
               line = "#{line} - #{summary}"
             end
@@ -312,6 +313,13 @@ module Brew
 
         puts "Found #{total_vulns} vulnerabilities in #{results.size} packages"
         1
+      end
+
+      def sanitize_terminal_escapes(text)
+        text
+          .gsub(/\e\][^\a]*(?:\a|\e\\)/, "")
+          .gsub(/\e\[[0-?]*[ -\/]*[@-~]/, "")
+          .delete("\e")
       end
 
       def colorize_severity(severity)

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -285,7 +285,7 @@ class TestCLI < Minitest::Test
 
   def test_text_output_sanitizes_terminal_escapes_from_summary
     formulae = [Brew::Vulns::Formula.new(@vim_data)]
-    summary = "safe \e[2J\e[31mred\e[0m \e]0;pwned\a text"
+    summary = "safe \e[2J\e[31mred\e[0m \e]0;pwned\a c1 \u009b2Jblue\u009d0;owned\a text"
 
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .to_return(status: 200, body: {
@@ -304,10 +304,58 @@ class TestCLI < Minitest::Test
       capture_stdout { Brew::Vulns::CLI.run([]) }
     end
 
-    assert_includes output, "safe red  text"
+    assert_includes output, "safe red  c1 blue text"
     refute_includes output, "\e"
+    refute_includes output, "\u009b"
+    refute_includes output, "\u009d"
     refute_includes output, "[2J"
     refute_includes output, "pwned"
+    refute_includes output, "owned"
+  end
+
+  def test_text_output_sanitizes_terminal_escapes_from_other_fields
+    formulae = [
+      Brew::Vulns::Formula.new(
+        @vim_data.merge(
+          "name" => "vim\e[2J",
+          "versions" => { "stable" => "9.1.0\e[31m" }
+        )
+      )
+    ]
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [{
+          vulns: [{ "id" => "CVE-2024-1234" }]
+        }]
+      }.to_json)
+
+    stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2024-1234")
+      .to_return(status: 200, body: {
+        "id" => "CVE-2024-1234\e[2J",
+        "affected" => [
+          {
+            "versions" => ["v9.1.0"],
+            "ranges" => [
+              {
+                "events" => [
+                  { "fixed" => "1.2.3\e[31m" }
+                ]
+              }
+            ]
+          }
+        ]
+      }.to_json)
+
+    output = Brew::Vulns::Formula.stub :load_installed, formulae do
+      capture_stdout { Brew::Vulns::CLI.run([]) }
+    end
+
+    assert_includes output, "vim (9.1.0)"
+    assert_includes output, "CVE-2024-1234 (UNKNOWN)"
+    assert_includes output, "Fixed in: 1.2.3"
+    refute_includes output, "\e"
+    refute_includes output, "[2J"
   end
 
   def test_severity_flag_filters_vulnerabilities

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -285,7 +285,7 @@ class TestCLI < Minitest::Test
 
   def test_text_output_sanitizes_terminal_escapes_from_summary
     formulae = [Brew::Vulns::Formula.new(@vim_data)]
-    summary = "safe \e[2J\e[31mred\e[0m \e]0;pwned\a c1 \u009b2Jblue\u009d0;owned\a text"
+    summary = "safe \e[2J\e[31mred\e[0m \e]0;pwned\a c1 \u009b2Jblue\u009d0;owned\a \rhidden\b text"
 
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .to_return(status: 200, body: {
@@ -304,10 +304,12 @@ class TestCLI < Minitest::Test
       capture_stdout { Brew::Vulns::CLI.run([]) }
     end
 
-    assert_includes output, "safe red  c1 blue text"
+    assert_includes output, "safe red  c1 blue hidden text"
     refute_includes output, "\e"
     refute_includes output, "\u009b"
     refute_includes output, "\u009d"
+    refute_includes output, "\r"
+    refute_includes output, "\b"
     refute_includes output, "[2J"
     refute_includes output, "pwned"
     refute_includes output, "owned"

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -283,6 +283,33 @@ class TestCLI < Minitest::Test
     refute_includes output, " - \n"
   end
 
+  def test_text_output_sanitizes_terminal_escapes_from_summary
+    formulae = [Brew::Vulns::Formula.new(@vim_data)]
+    summary = "safe \e[2J\e[31mred\e[0m \e]0;pwned\a text"
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [{
+          vulns: [{ "id" => "CVE-2024-1234" }]
+        }]
+      }.to_json)
+
+    stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2024-1234")
+      .to_return(status: 200, body: {
+        "id" => "CVE-2024-1234",
+        "summary" => summary
+      }.to_json)
+
+    output = Brew::Vulns::Formula.stub :load_installed, formulae do
+      capture_stdout { Brew::Vulns::CLI.run([]) }
+    end
+
+    assert_includes output, "safe red  text"
+    refute_includes output, "\e"
+    refute_includes output, "[2J"
+    refute_includes output, "pwned"
+  end
+
   def test_severity_flag_filters_vulnerabilities
     formulae = [Brew::Vulns::Formula.new(@vim_data)]
 


### PR DESCRIPTION
## Summary

Sanitizes OSV-provided vulnerability summaries before printing them in text output, preventing ANSI/terminal escape sequences from being interpreted by the user's terminal.

This removes CSI and OSC escape sequences from human-readable output while leaving machine-readable formats unchanged.

Fixes #45.

## Testing

- `bundle exec ruby -Itest test/brew/test_cli.rb`
- `bundle exec rake test`

Tests passed: 96 runs, 214 assertions, 0 failures.