### PR TITLE
Improve CVSS severity fallback handling

### DIFF
--- a/lib/brew/vulns/vulnerability.rb
+++ b/lib/brew/vulns/vulnerability.rb
@@ -7,6 +7,12 @@ require "cvss_suite"
 module Brew
   module Vulns
     class Vulnerability
+      CVSS_TYPE_PRIORITY = {
+        "CVSS_V4" => 4,
+        "CVSS_V3" => 3,
+        "CVSS_V2" => 2
+      }.freeze
+
       attr_reader :id, :summary, :details, :severity, :aliases, :references, :affected
 
       def initialize(data)
@@ -77,9 +83,9 @@ module Brew
 
       def extract_severity(data)
         if data["severity"]&.any?
-          sev = data["severity"].first
-          if sev["type"]&.include?("CVSS")
-            return severity_from_cvss(sev["score"])
+          cvss_severities(data["severity"]).each do |sev|
+            cvss_severity = severity_from_cvss(sev["score"])
+            return cvss_severity if cvss_severity
           end
         end
 
@@ -96,6 +102,12 @@ module Brew
         end
 
         nil
+      end
+
+      def cvss_severities(severities)
+        severities
+          .select { |sev| CVSS_TYPE_PRIORITY.key?(sev["type"]) }
+          .sort_by { |sev| -CVSS_TYPE_PRIORITY.fetch(sev["type"], 0) }
       end
 
       def normalize_severity(severity)

--- a/test/brew/test_vulnerability.rb
+++ b/test/brew/test_vulnerability.rb
@@ -144,6 +144,37 @@ class TestVulnerability < Minitest::Test
     assert_equal 0, vuln.severity_level
   end
 
+  def test_falls_back_to_database_specific_when_cvss_parse_fails
+    data = {
+      "id" => "CVE-2024-0003",
+      "severity" => [{ "type" => "CVSS_V3", "score" => "INVALID-CVSS" }],
+      "database_specific" => { "severity" => "HIGH" }
+    }
+
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert_equal "HIGH", vuln.severity_display
+    assert_equal 3, vuln.severity_level
+  end
+
+  def test_prefers_newer_cvss_versions_over_array_order
+    data = {
+      "id" => "CVE-2026-1234",
+      "severity" => [
+        { "type" => "CVSS_V2", "score" => "AV:L/AC:H/Au:S/C:P/I:P/A:N" },
+        { "type" => "CVSS_V4",
+          "score" => "CVSS:4.0/AV:N/AC:L/AT:N/PR:H/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N" },
+        { "type" => "CVSS_V3",
+          "score" => "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" }
+      ]
+    }
+
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert_equal "MEDIUM", vuln.severity_display
+    assert_equal 2, vuln.severity_level
+  end
+
   def test_extracts_severity_from_database_specific
     data = {
       "id" => "CVE-2024-1234",


### PR DESCRIPTION
Fixes #61

## Summary

Fixes two severity extraction issues in `Brew::Vulns::Vulnerability`:

1. If CVSS parsing returns `nil`, fall through to `database_specific.severity` / affected severity fallbacks instead of returning `nil` immediately.
2. When multiple CVSS severities are present, prefer `CVSS_V4` over `CVSS_V3`, and `CVSS_V3` over `CVSS_V2`, instead of depending on API array order.

## Testing

- `bundle exec ruby -Itest test/brew/test_vulnerability.rb`
- `bundle exec rake test`