### PR TITLE
Add --all flag to scan every homebrew-core formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ brew vulns [formula...] [options]
 
 | Flag | Long form | Description |
 |------|-----------|-------------|
+| | `--all` | Scan every formula in homebrew-core |
 | `-b PATH` | `--brewfile PATH` | Scan packages from a Brewfile (default: ./Brewfile) |
 | `-d` | `--deps` | Include dependencies when checking a specific formula or Brewfile |
 | `-j` | `--json` | Output results as JSON |
@@ -42,6 +43,9 @@ brew vulns [formula...] [options]
 ```bash
 # Check all installed packages
 brew vulns
+
+# Scan every formula in homebrew-core
+brew vulns --all --json > vulns.json
 
 # Check a specific formula (does not need to be installed)
 brew vulns openssl

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -15,6 +15,7 @@ module Brew
       def initialize(args)
         @args = args
         @formula_names = parse_formula_names(args)
+        @all = args.include?("--all")
         @include_deps = args.include?("--deps") || args.include?("-d")
         @json_output = args.include?("--json") || args.include?("-j")
         @sarif_output = args.include?("--sarif")
@@ -119,7 +120,9 @@ module Brew
       private
 
       def load_formulae
-        if @brewfile
+        if @all
+          Formula.load_all
+        elsif @brewfile
           Formula.load_from_brewfile(@brewfile, include_deps: @include_deps)
         elsif @formula_names.any?
           Formula.load_named(@formula_names, include_deps: @include_deps)
@@ -367,6 +370,7 @@ module Brew
             formula              Check only the named formulae (optional, does not need to be installed)
 
           Options:
+            --all                Scan every formula in homebrew-core
             -b, --brewfile PATH  Scan packages from a Brewfile (default: ./Brewfile)
             -d, --deps           Include dependencies when checking a specific formula or Brewfile
             -j, --json           Output results as JSON
@@ -378,6 +382,7 @@ module Brew
 
           Examples:
             brew vulns                    Check all installed packages
+            brew vulns --all --json       Scan every homebrew-core formula, output JSON
             brew vulns openssl            Check only openssl
             brew vulns vim curl jq        Check several formulae at once
             brew vulns vim --deps         Check vim and its dependencies

--- a/lib/brew/vulns/formula.rb
+++ b/lib/brew/vulns/formula.rb
@@ -50,6 +50,14 @@ module Brew
         { repo_url: repo_url, version: tag, name: name }
       end
 
+      def self.load_all
+        json, status = Open3.capture2("brew", "info", "--json=v2", "--eval-all")
+        raise Error, "brew info failed with status #{status.exitstatus}" unless status.success?
+
+        data = JSON.parse(json)
+        data["formulae"].map { |f| new(f) }
+      end
+
       def self.load_installed
         json, status = Open3.capture2("brew", "info", "--json=v2", "--installed")
         raise Error, "brew info failed with status #{status.exitstatus}" unless status.success?

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -632,7 +632,7 @@ class TestCLI < Minitest::Test
     assert_includes ["note", nil], result["level"]
   end
 
-  def test_all_flag_loads_from_formulae_api
+  def test_all_flag_uses_load_all
     formulae = [Brew::Vulns::Formula.new(@vim_data)]
 
     stub_request(:post, "https://api.osv.dev/v1/querybatch")

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -632,6 +632,53 @@ class TestCLI < Minitest::Test
     assert_includes ["note", nil], result["level"]
   end
 
+  def test_all_flag_loads_from_formulae_api
+    formulae = [Brew::Vulns::Formula.new(@vim_data)]
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: { results: [{ vulns: [] }] }.to_json)
+
+    load_all_called = false
+    load_all_mock = lambda do
+      load_all_called = true
+      formulae
+    end
+
+    Brew::Vulns::Formula.stub :load_all, load_all_mock do
+      result = Brew::Vulns::CLI.run(["--all"])
+      assert_equal 0, result
+    end
+
+    assert load_all_called
+  end
+
+  def test_all_flag_with_json_output
+    formulae = [Brew::Vulns::Formula.new(@vim_data)]
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [{
+          vulns: [{ "id" => "CVE-2024-1234" }]
+        }]
+      }.to_json)
+
+    stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2024-1234")
+      .to_return(status: 200, body: {
+        "id" => "CVE-2024-1234",
+        "summary" => "Test vulnerability",
+        "database_specific" => { "severity" => "HIGH" }
+      }.to_json)
+
+    output = Brew::Vulns::Formula.stub :load_all, formulae do
+      capture_stdout { Brew::Vulns::CLI.run(["--all", "--json"]) }
+    end
+    json = JSON.parse(output)
+
+    assert_equal 1, json.size
+    assert_equal "vim", json[0]["formula"]
+    assert_equal "CVE-2024-1234", json[0]["vulnerabilities"][0]["id"]
+  end
+
   def test_brewfile_flag_loads_from_brewfile
     formulae = [Brew::Vulns::Formula.new(@vim_data)]
 

--- a/test/brew/test_formula.rb
+++ b/test/brew/test_formula.rb
@@ -160,6 +160,49 @@ class TestFormula < Minitest::Test
     assert_equal ["gettext", "libsodium", "lua"], formula.dependencies
   end
 
+  def test_load_all_parses_brew_eval_all_output
+    brew_json = {
+      "formulae" => [
+        {
+          "name" => "vim",
+          "versions" => { "stable" => "9.1.0" },
+          "urls" => { "stable" => { "url" => "https://github.com/vim/vim/archive/refs/tags/v9.1.0.tar.gz" } }
+        },
+        {
+          "name" => "a2ps",
+          "versions" => { "stable" => "4.15.8" },
+          "urls" => { "stable" => { "url" => "https://ftpmirror.gnu.org/gnu/a2ps/a2ps-4.15.8.tar.gz" } }
+        }
+      ],
+      "casks" => []
+    }.to_json
+
+    success_status = Minitest::Mock.new
+    success_status.expect :success?, true
+
+    Open3.stub :capture2, [brew_json, success_status] do
+      formulae = Brew::Vulns::Formula.load_all
+
+      assert_equal 2, formulae.size
+      assert_equal "vim", formulae[0].name
+      assert_equal "https://github.com/vim/vim", formulae[0].repo_url
+      assert_equal "a2ps", formulae[1].name
+      assert_nil formulae[1].repo_url
+    end
+  end
+
+  def test_load_all_raises_on_brew_failure
+    failed_status = Minitest::Mock.new
+    failed_status.expect :success?, false
+    failed_status.expect :exitstatus, 1
+
+    Open3.stub :capture2, ["", failed_status] do
+      assert_raises(Brew::Vulns::Error) do
+        Brew::Vulns::Formula.load_all
+      end
+    end
+  end
+
   def test_load_named_queries_brew_info_without_installed
     brew_json = {
       "formulae" => [


### PR DESCRIPTION
Adds `brew vulns --all`, which scans every formula in homebrew-core rather than just installed packages. Formulae are loaded via `brew info --json=v2 --eval-all` and run through the existing OSV batch lookup.

Intended to be paired with `--json` and run on a schedule to produce a published vulnerability dump that Homebrew itself can eventually consume.