### PR TITLE
Accept multiple formula names and check uninstalled formulae

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Once installed, the command is available as `brew vulns`.
 ## Usage
 
 ```bash
-brew vulns [formula] [options]
+brew vulns [formula...] [options]
 ```
 
 ### Options
@@ -43,8 +43,11 @@ brew vulns [formula] [options]
 # Check all installed packages
 brew vulns
 
-# Check a specific formula
+# Check a specific formula (does not need to be installed)
 brew vulns openssl
+
+# Check several formulae at once
+brew vulns vim curl jq
 
 # Check a formula and its dependencies
 brew vulns python --deps
@@ -82,7 +85,7 @@ brew vulns --help
 
 ## How it works
 
-1. Reads installed Homebrew formulae via `brew info --json=v2 --installed`
+1. Reads Homebrew formulae via `brew info --json=v2` (installed packages by default, or any named formulae passed as arguments)
 2. Extracts the repository URL and version tag from each formula's source URL
 3. Queries the OSV API using the GIT ecosystem to find known vulnerabilities
 4. Reports any vulnerabilities found with their severity and CVE identifiers

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -10,10 +10,11 @@ module Brew
       DEFAULT_MAX_SUMMARY = 60
       SEVERITY_LEVELS = { "low" => 1, "medium" => 2, "high" => 3, "critical" => 4 }.freeze
       MAX_VULN_FETCH_THREADS = 15
+      FLAGS_WITH_VALUE = %w[-b --brewfile -m --max-summary -s --severity].freeze
 
       def initialize(args)
         @args = args
-        @formula_filter = args.first unless args.first&.start_with?("-")
+        @formula_names = parse_formula_names(args)
         @include_deps = args.include?("--deps") || args.include?("-d")
         @json_output = args.include?("--json") || args.include?("-j")
         @sarif_output = args.include?("--sarif")
@@ -22,6 +23,25 @@ module Brew
         @max_summary = parse_max_summary(args)
         @min_severity = parse_severity(args)
         @brewfile = parse_brewfile_path(args)
+      end
+
+      def parse_formula_names(args)
+        names = []
+        skip_next = false
+        args.each do |arg|
+          if skip_next
+            skip_next = false
+            next
+          end
+          if FLAGS_WITH_VALUE.include?(arg)
+            skip_next = true
+            next
+          end
+          next if arg.start_with?("-")
+
+          names << arg
+        end
+        names
       end
 
       def parse_max_summary(args)
@@ -70,7 +90,7 @@ module Brew
 
         formulae = load_formulae
         if formulae.empty?
-          puts "No installed formulae found."
+          puts "No formulae found."
           return 0
         end
 
@@ -101,10 +121,10 @@ module Brew
       def load_formulae
         if @brewfile
           Formula.load_from_brewfile(@brewfile, include_deps: @include_deps)
-        elsif @include_deps && @formula_filter
-          Formula.load_with_dependencies(@formula_filter)
+        elsif @formula_names.any?
+          Formula.load_named(@formula_names, include_deps: @include_deps)
         else
-          Formula.load_installed(@formula_filter)
+          Formula.load_installed
         end
       end
 
@@ -339,12 +359,12 @@ module Brew
 
       def print_help
         puts <<~HELP
-          Usage: brew vulns [formula] [options]
+          Usage: brew vulns [formula...] [options]
 
-          Check installed Homebrew packages for known vulnerabilities via osv.dev.
+          Check Homebrew packages for known vulnerabilities via osv.dev.
 
           Arguments:
-            formula              Check only this formula (optional)
+            formula              Check only the named formulae (optional, does not need to be installed)
 
           Options:
             -b, --brewfile PATH  Scan packages from a Brewfile (default: ./Brewfile)
@@ -359,6 +379,7 @@ module Brew
           Examples:
             brew vulns                    Check all installed packages
             brew vulns openssl            Check only openssl
+            brew vulns vim curl jq        Check several formulae at once
             brew vulns vim --deps         Check vim and its dependencies
             brew vulns --brewfile         Scan packages listed in ./Brewfile
             brew vulns -b ~/project/Brewfile  Scan a specific Brewfile

--- a/lib/brew/vulns/formula.rb
+++ b/lib/brew/vulns/formula.rb
@@ -50,51 +50,15 @@ module Brew
         { repo_url: repo_url, version: tag, name: name }
       end
 
-      def self.load_installed(formula_filter = nil)
+      def self.load_installed
         json, status = Open3.capture2("brew", "info", "--json=v2", "--installed")
         raise Error, "brew info failed with status #{status.exitstatus}" unless status.success?
 
         data = JSON.parse(json)
-        formulae = data["formulae"].map { |f| new(f) }
-
-        if formula_filter
-          formulae.select! { |f| f.name == formula_filter || f.name.split("@").first == formula_filter }
-        end
-
-        formulae
+        data["formulae"].map { |f| new(f) }
       end
 
-      def self.load_with_dependencies(formula_filter = nil)
-        json, status = Open3.capture2("brew", "info", "--json=v2", "--installed")
-        raise Error, "brew info failed with status #{status.exitstatus}" unless status.success?
-
-        data = JSON.parse(json)
-        all_formulae = data["formulae"].map { |f| new(f) }
-        formulae_by_name = all_formulae.each_with_object({}) { |f, h| h[f.name] = f }
-
-        if formula_filter
-          filtered = all_formulae.select { |f| f.name == formula_filter || f.name.split("@").first == formula_filter }
-          return [] if filtered.empty?
-
-          deps_output, = Open3.capture2("brew", "deps", "--installed", formula_filter)
-          dep_names = deps_output.split("\n").map(&:strip)
-
-          result = filtered.each_with_object({}) { |f, h| h[f.name] = f }
-          dep_names.each do |dep_name|
-            dep = formulae_by_name[dep_name]
-            result[dep_name] = dep if dep && !result[dep_name]
-          end
-
-          result.values
-        else
-          all_formulae
-        end
-      end
-
-      def self.load_from_brewfile(brewfile_path, include_deps: false)
-        raise Error, "Brewfile not found: #{brewfile_path}" unless File.exist?(brewfile_path)
-
-        formula_names = parse_brewfile(brewfile_path)
+      def self.load_named(formula_names, include_deps: false)
         return [] if formula_names.empty?
 
         json, status = Open3.capture2("brew", "info", "--json=v2", *formula_names)
@@ -122,6 +86,13 @@ module Brew
         end
 
         formulae.uniq { |f| f.name }
+      end
+
+      def self.load_from_brewfile(brewfile_path, include_deps: false)
+        raise Error, "Brewfile not found: #{brewfile_path}" unless File.exist?(brewfile_path)
+
+        formula_names = parse_brewfile(brewfile_path)
+        load_named(formula_names, include_deps: include_deps)
       end
 
       def self.parse_brewfile(brewfile_path)

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -128,18 +128,57 @@ class TestCLI < Minitest::Test
 
   def test_filters_by_formula_name
     vim = Brew::Vulns::Formula.new(@vim_data)
-    curl = Brew::Vulns::Formula.new(@curl_data)
-
-    load_mock = lambda do |filter|
-      filter == "vim" ? [vim] : [vim, curl]
-    end
 
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .to_return(status: 200, body: { results: [{ vulns: [] }] }.to_json)
 
-    Brew::Vulns::Formula.stub :load_installed, load_mock do
+    load_named_called = false
+    load_named_mock = lambda do |names, include_deps:|
+      load_named_called = true
+      assert_equal ["vim"], names
+      refute include_deps
+      [vim]
+    end
+
+    Brew::Vulns::Formula.stub :load_named, load_named_mock do
       result = Brew::Vulns::CLI.run(["vim"])
       assert_equal 0, result
+    end
+
+    assert load_named_called
+  end
+
+  def test_multiple_formula_names
+    vim = Brew::Vulns::Formula.new(@vim_data)
+    curl = Brew::Vulns::Formula.new(@curl_data)
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: { results: [{ vulns: [] }, { vulns: [] }] }.to_json)
+
+    load_named_mock = lambda do |names, include_deps:|
+      assert_equal ["vim", "curl"], names
+      [vim, curl]
+    end
+
+    Brew::Vulns::Formula.stub :load_named, load_named_mock do
+      result = Brew::Vulns::CLI.run(["vim", "curl"])
+      assert_equal 0, result
+    end
+  end
+
+  def test_formula_names_ignore_flag_values
+    vim = Brew::Vulns::Formula.new(@vim_data)
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: { results: [{ vulns: [] }] }.to_json)
+
+    load_named_mock = lambda do |names, include_deps:|
+      assert_equal ["vim"], names
+      [vim]
+    end
+
+    Brew::Vulns::Formula.stub :load_named, load_named_mock do
+      Brew::Vulns::CLI.run(["-m", "80", "vim", "-s", "high"])
     end
   end
 
@@ -149,18 +188,19 @@ class TestCLI < Minitest::Test
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
       .to_return(status: 200, body: { results: [{ vulns: [] }] }.to_json)
 
-    load_with_deps_called = false
-    load_with_deps_mock = lambda do |filter|
-      load_with_deps_called = true
-      assert_equal "vim", filter
+    load_named_called = false
+    load_named_mock = lambda do |names, include_deps:|
+      load_named_called = true
+      assert_equal ["vim"], names
+      assert include_deps
       [vim]
     end
 
-    Brew::Vulns::Formula.stub :load_with_dependencies, load_with_deps_mock do
+    Brew::Vulns::Formula.stub :load_named, load_named_mock do
       Brew::Vulns::CLI.run(["vim", "--deps"])
     end
 
-    assert load_with_deps_called
+    assert load_named_called
   end
 
   def test_output_truncates_long_summaries

--- a/test/brew/test_formula.rb
+++ b/test/brew/test_formula.rb
@@ -160,6 +160,96 @@ class TestFormula < Minitest::Test
     assert_equal ["gettext", "libsodium", "lua"], formula.dependencies
   end
 
+  def test_load_named_queries_brew_info_without_installed
+    brew_json = {
+      "formulae" => [
+        {
+          "name" => "vim",
+          "versions" => { "stable" => "9.1.0" },
+          "urls" => { "stable" => { "url" => "https://github.com/vim/vim/archive/refs/tags/v9.1.0.tar.gz" } }
+        },
+        {
+          "name" => "curl",
+          "versions" => { "stable" => "8.5.0" },
+          "urls" => { "stable" => { "url" => "https://github.com/curl/curl/archive/refs/tags/curl-8_5_0.tar.gz" } }
+        }
+      ]
+    }.to_json
+
+    success_status = Minitest::Mock.new
+    success_status.expect :success?, true
+
+    capture_mock = lambda do |*args|
+      assert_equal ["brew", "info", "--json=v2", "vim", "curl"], args
+      [brew_json, success_status]
+    end
+
+    Open3.stub :capture2, capture_mock do
+      formulae = Brew::Vulns::Formula.load_named(["vim", "curl"])
+      assert_equal 2, formulae.size
+      assert_equal "vim", formulae[0].name
+      assert_equal "curl", formulae[1].name
+    end
+  end
+
+  def test_load_named_returns_empty_for_empty_input
+    assert_equal [], Brew::Vulns::Formula.load_named([])
+  end
+
+  def test_load_named_raises_on_brew_failure
+    failed_status = Minitest::Mock.new
+    failed_status.expect :success?, false
+    failed_status.expect :exitstatus, 1
+
+    Open3.stub :capture2, ["", failed_status] do
+      assert_raises(Brew::Vulns::Error) do
+        Brew::Vulns::Formula.load_named(["nonexistent"])
+      end
+    end
+  end
+
+  def test_load_named_with_deps_includes_dependencies
+    brew_json = {
+      "formulae" => [
+        {
+          "name" => "vim",
+          "versions" => { "stable" => "9.1.0" },
+          "urls" => { "stable" => { "url" => "https://github.com/vim/vim/archive/refs/tags/v9.1.0.tar.gz" } }
+        }
+      ]
+    }.to_json
+
+    deps_json = {
+      "formulae" => [
+        {
+          "name" => "gettext",
+          "versions" => { "stable" => "0.22" },
+          "urls" => { "stable" => { "url" => "https://github.com/gnu/gettext/archive/refs/tags/v0.22.tar.gz" } }
+        }
+      ]
+    }.to_json
+
+    success_status = Minitest::Mock.new
+    3.times { success_status.expect :success?, true }
+
+    capture_mock = lambda do |*args|
+      case args
+      when ["brew", "info", "--json=v2", "vim"]
+        [brew_json, success_status]
+      when ["brew", "deps", "vim"]
+        ["gettext\n", success_status]
+      when ["brew", "info", "--json=v2", "gettext"]
+        [deps_json, success_status]
+      end
+    end
+
+    Open3.stub :capture2, capture_mock do
+      formulae = Brew::Vulns::Formula.load_named(["vim"], include_deps: true)
+      names = formulae.map(&:name).sort
+      assert_equal ["gettext", "vim"], names
+    end
+  end
+
   def test_load_installed_parses_brew_output
     brew_json = {
       "formulae" => [
@@ -187,57 +277,6 @@ class TestFormula < Minitest::Test
     end
   end
 
-  def test_load_installed_filters_by_name
-    brew_json = {
-      "formulae" => [
-        {
-          "name" => "vim",
-          "versions" => { "stable" => "9.1.0" },
-          "urls" => { "stable" => { "url" => "https://github.com/vim/vim/archive/refs/tags/v9.1.0.tar.gz" } }
-        },
-        {
-          "name" => "curl",
-          "versions" => { "stable" => "8.5.0" },
-          "urls" => { "stable" => { "url" => "https://github.com/curl/curl/archive/refs/tags/curl-8_5_0.tar.gz" } }
-        }
-      ]
-    }.to_json
-
-    success_status = Minitest::Mock.new
-    success_status.expect :success?, true
-
-    Open3.stub :capture2, [brew_json, success_status] do
-      formulae = Brew::Vulns::Formula.load_installed("vim")
-      assert_equal 1, formulae.size
-      assert_equal "vim", formulae[0].name
-    end
-  end
-
-  def test_load_installed_filters_versioned_formulae
-    brew_json = {
-      "formulae" => [
-        {
-          "name" => "python@3.11",
-          "versions" => { "stable" => "3.11.0" },
-          "urls" => { "stable" => { "url" => "https://github.com/python/cpython/archive/refs/tags/v3.11.0.tar.gz" } }
-        },
-        {
-          "name" => "python@3.12",
-          "versions" => { "stable" => "3.12.0" },
-          "urls" => { "stable" => { "url" => "https://github.com/python/cpython/archive/refs/tags/v3.12.0.tar.gz" } }
-        }
-      ]
-    }.to_json
-
-    success_status = Minitest::Mock.new
-    success_status.expect :success?, true
-
-    Open3.stub :capture2, [brew_json, success_status] do
-      formulae = Brew::Vulns::Formula.load_installed("python")
-      assert_equal 2, formulae.size
-    end
-  end
-
   def test_load_installed_raises_on_brew_failure
     failed_status = Minitest::Mock.new
     failed_status.expect :success?, false
@@ -247,74 +286,6 @@ class TestFormula < Minitest::Test
       assert_raises(Brew::Vulns::Error) do
         Brew::Vulns::Formula.load_installed
       end
-    end
-  end
-
-  def test_load_with_dependencies_includes_deps
-    brew_json = {
-      "formulae" => [
-        {
-          "name" => "vim",
-          "versions" => { "stable" => "9.1.0" },
-          "urls" => { "stable" => { "url" => "https://github.com/vim/vim/archive/refs/tags/v9.1.0.tar.gz" } }
-        },
-        {
-          "name" => "gettext",
-          "versions" => { "stable" => "0.22" },
-          "urls" => { "stable" => { "url" => "https://github.com/gnu/gettext/archive/refs/tags/v0.22.tar.gz" } }
-        },
-        {
-          "name" => "lua",
-          "versions" => { "stable" => "5.4.0" },
-          "urls" => { "stable" => { "url" => "https://github.com/lua/lua/archive/refs/tags/v5.4.0.tar.gz" } }
-        }
-      ]
-    }.to_json
-
-    deps_output = "gettext\nlua\n"
-
-    success_status = Minitest::Mock.new
-    2.times { success_status.expect :success?, true }
-
-    call_count = 0
-    capture_mock = lambda do |*args|
-      call_count += 1
-      if call_count == 1
-        [brew_json, success_status]
-      else
-        [deps_output, success_status]
-      end
-    end
-
-    Open3.stub :capture2, capture_mock do
-      formulae = Brew::Vulns::Formula.load_with_dependencies("vim")
-      names = formulae.map(&:name).sort
-      assert_equal ["gettext", "lua", "vim"], names
-    end
-  end
-
-  def test_load_with_dependencies_without_filter_returns_all
-    brew_json = {
-      "formulae" => [
-        {
-          "name" => "vim",
-          "versions" => { "stable" => "9.1.0" },
-          "urls" => { "stable" => { "url" => "https://github.com/vim/vim/archive/refs/tags/v9.1.0.tar.gz" } }
-        },
-        {
-          "name" => "curl",
-          "versions" => { "stable" => "8.5.0" },
-          "urls" => { "stable" => { "url" => "https://github.com/curl/curl/archive/refs/tags/curl-8_5_0.tar.gz" } }
-        }
-      ]
-    }.to_json
-
-    success_status = Minitest::Mock.new
-    success_status.expect :success?, true
-
-    Open3.stub :capture2, [brew_json, success_status] do
-      formulae = Brew::Vulns::Formula.load_with_dependencies
-      assert_equal 2, formulae.size
     end
   end
 


### PR DESCRIPTION
`brew vulns <name>` now resolves formulae via `brew info --json=v2 <name>` rather than filtering the `--installed` list, so it works whether or not the formula is on the local machine. Multiple names can be passed at once: `brew vulns vim curl jq`.

This is groundwork for running against changed formulae in homebrew-core PR CI.

`Formula.load_named` is extracted from the existing Brewfile loader and handles `--deps` for arbitrary names, so `Formula.load_with_dependencies` and the filter argument on `Formula.load_installed` are removed as dead code.

Behaviour change: `brew vulns python` now resolves to whatever `brew info python` returns rather than matching every installed `python@*`. Pass versioned names explicitly if you want more than one.