### PR TITLE
Add example workflows for tap PR checks and full-core scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ jobs:
 
 This adds your Homebrew packages to the repository's dependency graph, enabling Dependabot alerts.
 
+See [examples/](examples/) for workflows that check changed formulae on tap pull requests and publish a daily scan of all of homebrew-core.
+
 ## Development
 
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Example workflows
+
+GitHub Actions workflows showing how `brew vulns` can be wired into a Homebrew tap.
+
+`pr-vuln-check.yml` runs on pull requests that touch `Formula/**/*.rb`. It works out which formulae changed, runs `brew vulns <names> --sarif` against them, and uploads the result to GitHub code scanning so vulnerabilities appear as annotations on the PR.
+
+`scan-all.yml` runs daily, scans every formula in homebrew-core with `brew vulns --all --json`, and publishes `vulns.json` as an asset on a rolling `vulns` release. Downstream tooling (including Homebrew itself) can fetch that file rather than querying OSV directly.
+
+Copy whichever you need into `.github/workflows/` in the target repository and adjust to taste.

--- a/examples/pr-vuln-check.yml
+++ b/examples/pr-vuln-check.yml
@@ -1,0 +1,51 @@
+# Check formulae changed in a pull request for known vulnerabilities.
+# Intended for use in a Homebrew tap (e.g. homebrew-core).
+name: Vulnerability check
+
+on:
+  pull_request:
+    paths:
+      - "Formula/**/*.rb"
+
+permissions: {}
+
+jobs:
+  vulns:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+
+      - name: Install brew-vulns
+        run: brew install homebrew/brew-vulns/brew-vulns
+
+      - name: Detect changed formulae
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          cd "$(brew --repository "${GITHUB_REPOSITORY}")"
+          names=$(git diff --name-only --diff-filter=AM "${BASE_SHA}...${HEAD_SHA}" -- Formula/ \
+            | xargs -r -n1 basename \
+            | sed 's/\.rb$//' \
+            | tr '\n' ' ')
+          echo "names=${names}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check vulnerabilities
+        if: steps.changed.outputs.names != ''
+        env:
+          FORMULAE: ${{ steps.changed.outputs.names }}
+        run: brew vulns ${FORMULAE} --sarif > vulns.sarif
+        continue-on-error: true
+
+      - name: Upload SARIF
+        if: steps.changed.outputs.names != ''
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          sarif_file: vulns.sarif
+          category: brew-vulns

--- a/examples/pr-vuln-check.yml
+++ b/examples/pr-vuln-check.yml
@@ -27,24 +27,28 @@ jobs:
         id: changed
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           cd "$(brew --repository "${GITHUB_REPOSITORY}")"
-          names=$(git diff --name-only --diff-filter=AM "${BASE_SHA}...${HEAD_SHA}" -- Formula/ \
+          git fetch --quiet --depth=1 origin "${BASE_SHA}"
+          names=$(git diff --name-only --diff-filter=AM "${BASE_SHA}" -- Formula/ \
             | xargs -r -n1 basename \
             | sed 's/\.rb$//' \
             | tr '\n' ' ')
           echo "names=${names}" >> "${GITHUB_OUTPUT}"
 
       - name: Check vulnerabilities
+        id: scan
         if: steps.changed.outputs.names != ''
         env:
           FORMULAE: ${{ steps.changed.outputs.names }}
-        run: brew vulns ${FORMULAE} --sarif > vulns.sarif
-        continue-on-error: true
+        run: |
+          brew vulns ${FORMULAE} --sarif > vulns.sarif || true
+          if [ -s vulns.sarif ]; then
+            echo "sarif=true" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Upload SARIF
-        if: steps.changed.outputs.names != ''
+        if: steps.scan.outputs.sarif == 'true'
         uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: vulns.sarif

--- a/examples/pr-vuln-check.yml
+++ b/examples/pr-vuln-check.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           FORMULAE: ${{ steps.changed.outputs.names }}
         run: |
-          brew vulns ${FORMULAE} --sarif > vulns.sarif || true
+          brew vulns ${FORMULAE} --sarif > vulns.sarif || [ $? -eq 1 ]
           if [ -s vulns.sarif ]; then
             echo "sarif=true" >> "${GITHUB_OUTPUT}"
           fi

--- a/examples/scan-all.yml
+++ b/examples/scan-all.yml
@@ -25,6 +25,9 @@ jobs:
         run: brew vulns --all --json > vulns.json
         continue-on-error: true
 
+      - name: Validate output
+        run: ruby -rjson -e 'abort "vulns.json is not a JSON array" unless JSON.load_file("vulns.json").is_a?(Array)'
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -36,5 +39,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release create vulns --title "Vulnerability data" --notes "Rolling vulnerability scan of homebrew-core" || true
+          if ! gh release view vulns >/dev/null 2>&1; then
+            gh release create vulns --title "Vulnerability data" --notes "Rolling vulnerability scan of homebrew-core"
+          fi
           gh release upload vulns vulns.json --clobber

--- a/examples/scan-all.yml
+++ b/examples/scan-all.yml
@@ -1,0 +1,40 @@
+# Scan every formula in homebrew-core for known vulnerabilities and
+# publish the result as vulns.json on a rolling release.
+name: Scan all formulae
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+
+      - name: Install brew-vulns
+        run: brew install homebrew/brew-vulns/brew-vulns
+
+      - name: Scan
+        run: brew vulns --all --json > vulns.json
+        continue-on-error: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vulns
+          path: vulns.json
+
+      - name: Publish to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release create vulns --title "Vulnerability data" --notes "Rolling vulnerability scan of homebrew-core" || true
+          gh release upload vulns vulns.json --clobber


### PR DESCRIPTION
Adds an `examples/` directory with two GitHub Actions workflows:

`pr-vuln-check.yml` runs on tap pull requests that touch `Formula/`, works out which formulae changed, runs `brew vulns <names> --sarif` against them, and uploads the result to code scanning so vulnerabilities show as PR annotations.

`scan-all.yml` runs daily, scans every homebrew-core formula with `brew vulns --all --json`, and publishes `vulns.json` on a rolling release for downstream consumption.

Both pass zizmor. Depends on the `--all` flag from #76 and multi-name support from #77.