### PR TITLE
Exit 2 on errors to distinguish from vulnerabilities found

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Found 15 vulnerabilities in 3 packages
 ## Exit codes
 
 - `0` - No vulnerabilities found
-- `1` - Vulnerabilities found (or error occurred)
+- `1` - Vulnerabilities found
+- `2` - An error occurred (network failure, `brew` failure, parse error)
 
 This makes it suitable for use in CI/CD pipelines.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Found 15 vulnerabilities in 3 packages
 - `1` - Vulnerabilities found
 - `2` - An error occurred (network failure, `brew` failure, parse error)
 
-This makes it suitable for use in CI/CD pipelines.
+This makes it suitable for use in CI/CD pipelines. To let a job continue when vulnerabilities are found but still fail on scan errors, use `brew vulns ... || [ $? -eq 1 ]`.
 
 ## GitHub Actions
 
@@ -135,8 +135,7 @@ jobs:
         run: gem install brew-vulns
 
       - name: Run vulnerability scan
-        run: brew vulns --sarif > results.sarif
-        continue-on-error: true
+        run: brew vulns --sarif > results.sarif || [ $? -eq 1 ]
 
       - name: Upload SARIF results
         uses: github/codeql-action/upload-sarif@v3
@@ -168,8 +167,7 @@ jobs:
         run: gem install brew-vulns
 
       - name: Generate SBOM
-        run: brew vulns --cyclonedx > sbom.cdx.json
-        continue-on-error: true
+        run: brew vulns --cyclonedx > sbom.cdx.json || [ $? -eq 1 ]
 
       - name: Submit to dependency graph
         uses: evryfs/sbom-dependency-submission-action@v0

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -87,13 +87,13 @@ module Brew
         output_results(results, formulae)
       rescue OsvClient::Error => e
         $stderr.puts "Error querying OSV: #{e.message}"
-        1
+        2
       rescue Error => e
         $stderr.puts "Error: #{e.message}"
-        1
+        2
       rescue JSON::ParserError => e
         $stderr.puts "Error parsing brew output: #{e.message}"
-        1
+        2
       end
 
       private

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -114,7 +114,7 @@ class TestCLI < Minitest::Test
     end
   end
 
-  def test_api_error_returns_one
+  def test_api_error_returns_two
     formulae = [Brew::Vulns::Formula.new(@vim_data)]
 
     stub_request(:post, "https://api.osv.dev/v1/querybatch")
@@ -122,7 +122,14 @@ class TestCLI < Minitest::Test
 
     Brew::Vulns::Formula.stub :load_installed, formulae do
       result = Brew::Vulns::CLI.run([])
-      assert_equal 1, result
+      assert_equal 2, result
+    end
+  end
+
+  def test_load_error_returns_two
+    Brew::Vulns::Formula.stub :load_installed, ->(*) { raise Brew::Vulns::Error, "boom" } do
+      result = Brew::Vulns::CLI.run([])
+      assert_equal 2, result
     end
   end
 

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -133,6 +133,13 @@ class TestCLI < Minitest::Test
     end
   end
 
+  def test_json_parse_error_returns_two
+    Brew::Vulns::Formula.stub :load_installed, ->(*) { raise JSON::ParserError, "unexpected token" } do
+      result = Brew::Vulns::CLI.run([])
+      assert_equal 2, result
+    end
+  end
+
   def test_filters_by_formula_name
     vim = Brew::Vulns::Formula.new(@vim_data)
     curl = Brew::Vulns::Formula.new(@curl_data)


### PR DESCRIPTION
Errors (OSV API failures, `brew` failures, JSON parse errors) now exit `2` instead of `1`. Exit `1` is reserved for "scan completed and vulnerabilities were found".

This lets CI workflows tell the two apart: tolerate `1` so a vulnerable formula doesn't fail the job, but still fail hard on `2` so a broken scan doesn't get silently treated as clean. The example workflows in #78 currently work around the ambiguity by validating output files, which this makes unnecessary.

Behaviour change for anyone currently treating exit `1` as "something went wrong".