### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 ## [Unreleased]
 
-- Set User-Agent header on OSV API requests (#49)
+## [0.3.0] - 2026-05-29
+
+- Add `--all` flag to scan every formula in homebrew-core
+- Accept one or more formula names as arguments to scan specific formulae, including ones that are not installed
+- Exit with status 2 on errors so callers can distinguish errors from "vulnerabilities found" (exit 1)
+- Add example GitHub Actions workflows for tap PR checks and full homebrew-core scans
+- Compute severity bands from CVSS vector strings when OSV data does not provide a severity label
+- Improve CVSS severity fallback handling when multiple score sources are present
+- Handle unbounded `introduced: 0` OSV ranges and multi-interval SEMVER ranges correctly
+- Fail closed (report as affected) when a version range comparison raises instead of silently skipping
+- Sanitize ANSI/terminal escape sequences, carriage returns and backspaces from text output
+- Cap concurrent requests when fetching vulnerability details to avoid unbounded thread spawning
+- Cap OSV pagination at a fixed page limit to avoid unbounded loops on bad responses
+- Set a `User-Agent` header on OSV API requests
+
+## [0.2.3] - 2026-02-05
+
+- Move repository to the Homebrew organisation and update install instructions, formula and links accordingly
+- Internal: shared CI/lint configuration sync and dependency updates
 
 ## [0.2.2] - 2026-01-25
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    brew-vulns (0.2.3)
+    brew-vulns (0.3.0)
       cvss-suite (~> 4.1)
       purl (~> 1.6)
       sarif-ruby (~> 0.1)
@@ -95,7 +95,7 @@ DEPENDENCIES
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   bigdecimal (3.3.1) sha256=eaa01e228be54c4f9f53bf3cc34fe3d5e845c31963e7fcc5bedb05a4e7d52218
-  brew-vulns (0.2.3)
+  brew-vulns (0.3.0)
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   cvss-suite (4.1.3) sha256=625cdebdf2a1a940450d11bb8c8637b96c7004fb48559d59700079ca7a6f875c
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0

--- a/lib/brew/vulns/version.rb
+++ b/lib/brew/vulns/version.rb
@@ -2,6 +2,6 @@
 
 module Brew
   module Vulns
-    VERSION = "0.2.3"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
Prepare the 0.3.0 release.

- Bump `VERSION` to 0.3.0 and regenerate `Gemfile.lock`
- Add 0.3.0 changelog covering changes since v0.2.3
- Backfill the missing 0.2.3 changelog entry

The formula update will follow in a separate PR once the tag is pushed and the tarball sha256 is known.