### PR TITLE
Show command help for brew vulns

### DIFF
--- a/Formula/brew-vulns.rb
+++ b/Formula/brew-vulns.rb
@@ -8,15 +8,13 @@ class BrewVulns < Formula
   depends_on "ruby"
 
   def install
-    ENV["GEM_HOME"] = libexec
-
     system "git", "init"
     system "git", "add", "."
 
     system "gem", "build", "brew-vulns.gemspec"
-    system "gem", "install", "--no-document", "brew-vulns-#{version}.gem"
-    bin.install libexec/"bin/brew-vulns"
-    bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV.fetch("GEM_HOME", nil))
+    system "gem", "install", "--no-document", "--install-dir", libexec,
+           "--bindir", libexec/"bin", "brew-vulns-#{version}.gem"
+
     (bin/"brew-vulns").write <<~BASH
       #!/bin/bash
       #:  * `vulns` [<formula>...] [<options>]
@@ -42,12 +40,15 @@ class BrewVulns < Formula
       #:  `-h`, `--help`
       #:    Show this help message.
 
-      GEM_HOME="#{libexec}" exec "#{libexec}/bin/brew-vulns" "$@"
+      export GEM_HOME="#{libexec}"
+      export GEM_PATH="#{libexec}"
+      exec "#{libexec}/bin/brew-vulns" "$@"
     BASH
     chmod 0755, bin/"brew-vulns"
   end
 
   test do
-    assert_match "Usage: brew vulns", shell_output("brew vulns --help")
+    assert_match(/^#:  \* `vulns`/, (bin/"brew-vulns").read)
+    assert_match "Usage: brew vulns", shell_output("#{bin}/brew-vulns --help")
   end
 end

--- a/Formula/brew-vulns.rb
+++ b/Formula/brew-vulns.rb
@@ -17,9 +17,37 @@ class BrewVulns < Formula
     system "gem", "install", "--no-document", "brew-vulns-#{version}.gem"
     bin.install libexec/"bin/brew-vulns"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV.fetch("GEM_HOME", nil))
+    (bin/"brew-vulns").write <<~BASH
+      #!/bin/bash
+      #:  * `vulns` [<formula>...] [<options>]
+      #:
+      #:  Check Homebrew packages for known vulnerabilities via osv.dev.
+      #:
+      #:  `--all`
+      #:    Scan every formula in homebrew-core.
+      #:  `-b`, `--brewfile` <path>
+      #:    Scan packages from a Brewfile.
+      #:  `-d`, `--deps`
+      #:    Include dependencies.
+      #:  `-j`, `--json`
+      #:    Output results as JSON.
+      #:  `--cyclonedx`
+      #:    Output results as a CycloneDX SBOM.
+      #:  `--sarif`
+      #:    Output results as SARIF.
+      #:  `-m`, `--max-summary` <n>
+      #:    Truncate summaries to N characters.
+      #:  `-s`, `--severity` <level>
+      #:    Only show vulnerabilities at or above LEVEL.
+      #:  `-h`, `--help`
+      #:    Show this help message.
+
+      GEM_HOME="#{libexec}" exec "#{libexec}/bin/brew-vulns" "$@"
+    BASH
+    chmod 0755, bin/"brew-vulns"
   end
 
   test do
-    system bin/"brew-vulns", "--help"
+    assert_match "Usage: brew vulns", shell_output("brew vulns --help")
   end
 end


### PR DESCRIPTION
## Summary

Adds Homebrew-readable help comments to the installed `brew-vulns` wrapper so `brew vulns --help` displays command-specific help instead of the top-level `brew --help` page.

Fixes #85.

## Testing

- `ruby -c Formula/brew-vulns.rb`
- `rbenv exec bundle exec rake test`
- `brew style Formula/brew-vulns.rb`