### PR TITLE
Suppress vulnerabilities resolved by formula patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
-- Suppress vulnerabilities that a formula's patches declare as resolved (via `patches[].resolves` in `brew info --json=v2`, Homebrew 6.0.4+); list them separately in text/JSON output and exclude them from SARIF/CycloneDX output and the exit code
+- Suppress vulnerabilities that a formula's patches declare as resolved (via `patches[].resolves` in `brew info --json=v2`, Homebrew 6.0.4+); list them separately in text/JSON output, exclude them from SARIF output, and exclude them from the exit code
+- CycloneDX output: emit patched vulnerabilities with `analysis.state = resolved` and include formula patches as `pedigree.patches` on each component
 - Add `--no-ignore-patches` to report patched vulnerabilities as open findings
 
 ## [0.3.0] - 2026-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Suppress vulnerabilities that a formula's patches declare as resolved (via `patches[].resolves` in `brew info --json=v2`, Homebrew 6.0.4+); list them separately in text/JSON output and exclude them from SARIF/CycloneDX output and the exit code
+- Add `--no-ignore-patches` to report patched vulnerabilities as open findings
+
 ## [0.3.0] - 2026-05-29
 
 - Add `--all` flag to scan every formula in homebrew-core

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       cvss-suite (~> 4.1)
       purl (~> 1.6)
       sarif-ruby (~> 0.1, >= 0.1.1)
-      sbom (~> 0.4)
+      sbom (~> 0.5)
       vers (~> 1.0)
 
 GEM
@@ -60,7 +60,7 @@ GEM
       io-console (~> 0.5)
     rexml (3.4.4)
     sarif-ruby (0.1.1)
-    sbom (0.4.1)
+    sbom (0.5.0)
       json_schemer (~> 2.0)
       purl (~> 1.6)
       rexml (~> 3.2)
@@ -121,7 +121,7 @@ CHECKSUMS
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   sarif-ruby (0.1.1) sha256=35d5a89b484954833825771f9aff650b80bc209ebc53585ba66fff4221b33225
-  sbom (0.4.1) sha256=0c0cb49c43048f53c7eacaa536064704747825f3ba6b607dfe481aab9c591f37
+  sbom (0.5.0) sha256=272ee86d6696bc4078d14f50ba7183aadcaa3d6726af9a3d247fdc36c5a89e1e
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ brew vulns [formula...] [options]
 | | `--all` | Scan every formula in homebrew-core |
 | `-b PATH` | `--brewfile PATH` | Scan packages from a Brewfile (default: ./Brewfile) |
 | `-d` | `--deps` | Include dependencies when checking a specific formula or Brewfile |
+| | `--no-ignore-patches` | Report vulnerabilities even when the formula applies a patch that resolves them |
 | `-j` | `--json` | Output results as JSON |
 | | `--cyclonedx` | Output results as CycloneDX SBOM with vulnerabilities |
 | | `--sarif` | Output results as SARIF for GitHub code scanning |
@@ -95,6 +96,12 @@ brew vulns --help
 4. Reports any vulnerabilities found with their severity and CVE identifiers
 
 Packages with GitHub, GitLab, or Codeberg source URLs are checked. Packages from other sources are skipped.
+
+### Patched vulnerabilities
+
+Some Homebrew formulae apply patches that fix CVEs without changing the upstream version number. Where a formula's `patch` block declares (or infers) a `resolves` entry for a CVE or GHSA identifier, `brew vulns` treats matching OSV results as already resolved: they are listed separately in text and `--json` output, omitted from `--sarif` and `--cyclonedx` output, and do not affect the exit code. Pass `--no-ignore-patches` to report them as open findings instead.
+
+This relies on `patches[].resolves` data in `brew info --json=v2`, available from Homebrew 6.0.4 onwards. With an older Homebrew, or for formulae whose patches are not yet annotated, no suppression happens.
 
 ## Example output
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Packages with GitHub, GitLab, or Codeberg source URLs are checked. Packages from
 
 ### Patched vulnerabilities
 
-Some Homebrew formulae apply patches that fix CVEs without changing the upstream version number. Where a formula's `patch` block declares (or infers) a `resolves` entry for a CVE or GHSA identifier, `brew vulns` treats matching OSV results as already resolved: they are listed separately in text and `--json` output, omitted from `--sarif` and `--cyclonedx` output, and do not affect the exit code. Pass `--no-ignore-patches` to report them as open findings instead.
+Some Homebrew formulae apply patches that fix CVEs without changing the upstream version number. Where a formula's `patch` block declares (or infers) a `resolves` entry for a CVE or GHSA identifier, `brew vulns` treats matching OSV results as already resolved: they are listed separately in text and `--json` output, omitted from `--sarif` output, emitted in `--cyclonedx` output with `analysis.state` set to `resolved`, and do not affect the exit code. The CycloneDX SBOM also records each formula's patches under `components[].pedigree.patches`. Pass `--no-ignore-patches` to report them as open findings instead.
 
 This relies on `patches[].resolves` data in `brew info --json=v2`, available from Homebrew 6.0.4 onwards. With an older Homebrew, or for formulae whose patches are not yet annotated, no suppression happens.
 

--- a/brew-vulns.gemspec
+++ b/brew-vulns.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "cvss-suite", "~> 4.1"
   spec.add_dependency "purl", "~> 1.6"
   spec.add_dependency "sarif-ruby", "~> 0.1", ">= 0.1.1"
-  spec.add_dependency "sbom", "~> 0.4"
+  spec.add_dependency "sbom", "~> 0.5"
   spec.add_dependency "vers", "~> 1.0"
 end

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -316,7 +316,7 @@ module Brew
 
       def output_text(results, patched, all_formulae)
         if results.empty?
-          puts "No vulnerabilities found."
+          puts patched.empty? ? "No vulnerabilities found." : "No open vulnerabilities found."
           output_patched_summary(patched)
           return 0
         end

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -170,7 +170,7 @@ module Brew
 
       def output_results(results, patched, all_formulae)
         if @cyclonedx_output
-          output_cyclonedx(results, all_formulae)
+          output_cyclonedx(results, patched, all_formulae)
         elsif @sarif_output
           output_sarif(results)
         elsif @json_output
@@ -207,29 +207,35 @@ module Brew
         results.empty? ? 0 : 1
       end
 
-      def output_cyclonedx(results, all_formulae)
+      def output_cyclonedx(results, patched, all_formulae)
         components = all_formulae.map do |formula|
-          {
+          component = {
             type:    "library",
             name:    formula.name,
             version: formula.version,
             purl:    "pkg:brew/#{formula.name}@#{formula.version}",
           }
+          pedigree = formula.cyclonedx_pedigree
+          component[:pedigree] = pedigree if pedigree
+          component
         end
 
-        # Vulnerabilities resolved by formula patches are omitted. CycloneDX models this via
-        # `analysis.state = resolved` (and `pedigree.patches` on the component), but the `sbom`
-        # gem does not yet pass either through, so emitting them would look like open findings.
         vulnerabilities = []
         results.each do |formula, vulns|
           vulns.each do |vuln|
-            vulnerabilities << {
-              id:          vuln.id,
-              source:      { name: "OSV", url: "https://osv.dev" },
-              ratings:     [{ severity: vuln.severity_display&.downcase }],
-              description: vuln.summary,
-              affects:     [{ ref: "pkg:brew/#{formula.name}@#{formula.version}" }],
-            }
+            vulnerabilities << cyclonedx_vulnerability(formula, vuln)
+          end
+        end
+        patched.each do |formula, vulns|
+          vulns.each do |vuln|
+            matched = (formula.resolved_vulnerability_ids & vuln.identifiers.map { |i| i.to_s.upcase }).join(", ")
+            vulnerabilities << cyclonedx_vulnerability(formula, vuln).merge(
+              analysis: {
+                state:    "resolved",
+                response: ["update"],
+                detail:   "Resolved by Homebrew formula patch (#{matched}).",
+              },
+            )
           end
         end
 
@@ -241,6 +247,16 @@ module Brew
 
         puts generator.output
         results.empty? ? 0 : 1
+      end
+
+      def cyclonedx_vulnerability(formula, vuln)
+        {
+          id:          vuln.id,
+          source:      { name: "OSV", url: "https://osv.dev" },
+          ratings:     [{ severity: vuln.severity_display&.downcase }],
+          description: vuln.summary,
+          affects:     [{ ref: "pkg:brew/#{formula.name}@#{formula.version}" }],
+        }
       end
 
       def output_sarif(results)

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -17,6 +17,7 @@ module Brew
         @formula_names = parse_formula_names(args)
         @all = args.include?("--all")
         @include_deps = args.include?("--deps") || args.include?("-d")
+        @ignore_patches = !args.include?("--no-ignore-patches")
         @json_output = args.include?("--json") || args.include?("-j")
         @sarif_output = args.include?("--sarif")
         @cyclonedx_output = args.include?("--cyclonedx")
@@ -104,8 +105,8 @@ module Brew
           puts
         end
 
-        results = scan_vulnerabilities(queryable)
-        output_results(results, formulae)
+        results, patched = scan_vulnerabilities(queryable)
+        output_results(results, patched, formulae)
       rescue OsvClient::Error => e
         $stderr.puts "Error querying OSV: #{e.message}"
         2
@@ -138,6 +139,7 @@ module Brew
         vuln_results = client.query_batch(queries)
 
         results = {}
+        patched = {}
         formulae.each_with_index do |formula, idx|
           batch_vulns = vuln_results[idx] || []
           next if batch_vulns.empty?
@@ -155,40 +157,49 @@ module Brew
           vulns = vulns.select { |v| v.affects_version?(version) }
           vulns = vulns.select { |v| v.severity_level >= @min_severity } if @min_severity > 0
 
+          if @ignore_patches
+            resolved, vulns = vulns.partition { |v| formula.resolves?(v) }
+            patched[formula] = resolved if resolved.any?
+          end
+
           results[formula] = vulns if vulns.any?
         end
 
-        results
+        [results, patched]
       end
 
-      def output_results(results, all_formulae)
+      def output_results(results, patched, all_formulae)
         if @cyclonedx_output
           output_cyclonedx(results, all_formulae)
         elsif @sarif_output
           output_sarif(results)
         elsif @json_output
-          output_json(results)
+          output_json(results, patched)
         else
-          output_text(results, all_formulae)
+          output_text(results, patched, all_formulae)
         end
       end
 
-      def output_json(results)
-        data = results.map do |formula, vulns|
+      def vuln_json(vuln)
+        {
+          id:             vuln.id,
+          severity:       vuln.severity_display,
+          summary:        vuln.summary,
+          aliases:        vuln.aliases,
+          fixed_versions: vuln.fixed_versions,
+        }
+      end
+
+      def output_json(results, patched)
+        formulae = (results.keys + patched.keys).uniq
+        data = formulae.map do |formula|
           {
-            formula: formula.name,
-            version: formula.version,
-            tag: formula.tag,
-            repo_url: formula.repo_url,
-            vulnerabilities: vulns.map do |v|
-              {
-                id: v.id,
-                severity: v.severity_display,
-                summary: v.summary,
-                aliases: v.aliases,
-                fixed_versions: v.fixed_versions
-              }
-            end
+            formula:         formula.name,
+            version:         formula.version,
+            tag:             formula.tag,
+            repo_url:        formula.repo_url,
+            vulnerabilities: (results[formula] || []).map { |v| vuln_json(v) },
+            patched:         (patched[formula] || []).map { |v| vuln_json(v) },
           }
         end
 
@@ -199,30 +210,33 @@ module Brew
       def output_cyclonedx(results, all_formulae)
         components = all_formulae.map do |formula|
           {
-            type: "library",
-            name: formula.name,
+            type:    "library",
+            name:    formula.name,
             version: formula.version,
-            purl: "pkg:brew/#{formula.name}@#{formula.version}"
+            purl:    "pkg:brew/#{formula.name}@#{formula.version}",
           }
         end
 
+        # Vulnerabilities resolved by formula patches are omitted. CycloneDX models this via
+        # `analysis.state = resolved` (and `pedigree.patches` on the component), but the `sbom`
+        # gem does not yet pass either through, so emitting them would look like open findings.
         vulnerabilities = []
         results.each do |formula, vulns|
           vulns.each do |vuln|
             vulnerabilities << {
-              id: vuln.id,
-              source: { name: "OSV", url: "https://osv.dev" },
-              ratings: [{ severity: vuln.severity_display&.downcase }],
+              id:          vuln.id,
+              source:      { name: "OSV", url: "https://osv.dev" },
+              ratings:     [{ severity: vuln.severity_display&.downcase }],
               description: vuln.summary,
-              affects: [{ ref: "pkg:brew/#{formula.name}@#{formula.version}" }]
+              affects:     [{ ref: "pkg:brew/#{formula.name}@#{formula.version}" }],
             }
           end
         end
 
         generator = Sbom::Cyclonedx::Generator.new(format: :json)
         generator.generate("brew-vulns", {
-          packages: components,
-          vulnerabilities: vulnerabilities
+          packages:        components,
+          vulnerabilities: vulnerabilities,
         })
 
         puts generator.output
@@ -300,9 +314,10 @@ module Brew
         end
       end
 
-      def output_text(results, all_formulae)
+      def output_text(results, patched, all_formulae)
         if results.empty?
           puts "No vulnerabilities found."
+          output_patched_summary(patched)
           return 0
         end
 
@@ -336,7 +351,20 @@ module Brew
         end
 
         puts "Found #{total_vulns} vulnerabilities in #{results.size} packages"
+        output_patched_summary(patched)
         1
+      end
+
+      def output_patched_summary(patched)
+        return if patched.empty?
+
+        total = patched.values.sum(&:size)
+        puts
+        puts "#{total} resolved by formula patches (not counted; pass --no-ignore-patches to include):"
+        patched.sort_by { |f, _| f.name }.each do |formula, vulns|
+          ids = vulns.map { |v| sanitize_terminal_escapes(v.id) }.join(", ")
+          puts "  #{sanitize_terminal_escapes(formula.name)}: #{ids}"
+        end
       end
 
       def sanitize_terminal_escapes(text)
@@ -373,6 +401,7 @@ module Brew
             --all                Scan every formula in homebrew-core
             -b, --brewfile PATH  Scan packages from a Brewfile (default: ./Brewfile)
             -d, --deps           Include dependencies when checking a specific formula or Brewfile
+            --no-ignore-patches  Report vulnerabilities even when the formula applies a patch that resolves them
             -j, --json           Output results as JSON
             --cyclonedx          Output results as CycloneDX SBOM with vulnerabilities
             --sarif              Output results as SARIF for GitHub code scanning

--- a/lib/brew/vulns/formula.rb
+++ b/lib/brew/vulns/formula.rb
@@ -37,6 +37,34 @@ module Brew
         vulnerability.identifiers.any? { |id| ids.include?(id.to_s.upcase) }
       end
 
+      CYCLONEDX_PATCH_TYPES = {
+        "backport"    => "backport",
+        "cherry_pick" => "cherry-pick",
+        "unofficial"  => "unofficial",
+      }.freeze
+
+      # Maps `brew info --json=v2` patch data to a CycloneDX `pedigree` hash
+      # (symbol-keyed for the `sbom` gem). Returns nil when there are no patches.
+      def cyclonedx_pedigree
+        return nil if patches.empty?
+
+        cdx_patches = patches.map do |p|
+          patch = { type: CYCLONEDX_PATCH_TYPES.fetch(p["type"].to_s, "unofficial") }
+          patch[:diff] = { url: p["url"] } if p["url"]
+
+          resolves = Array(p["resolves"]).filter_map do |r|
+            next unless r.is_a?(Hash) && r["type"] && r["id"]
+
+            { type: r["type"], id: r["id"] }
+          end
+          patch[:resolves] = resolves if resolves.any?
+
+          patch
+        end
+
+        { patches: cdx_patches }
+      end
+
       def repo_url
         return @repo_url if defined?(@repo_url)
 

--- a/lib/brew/vulns/formula.rb
+++ b/lib/brew/vulns/formula.rb
@@ -27,6 +27,7 @@ module Brew
           .flat_map { |p| Array(p["resolves"]) }
           .select { |r| r.is_a?(Hash) && r["type"] == "security" }
           .map { |r| r["id"].to_s.upcase }
+          .reject(&:empty?)
           .uniq
       end
 

--- a/lib/brew/vulns/formula.rb
+++ b/lib/brew/vulns/formula.rb
@@ -6,7 +6,7 @@ require "open3"
 module Brew
   module Vulns
     class Formula
-      attr_reader :name, :version, :source_url, :head_url, :dependencies
+      attr_reader :name, :version, :source_url, :head_url, :dependencies, :patches
 
       def initialize(data)
         @name = data["name"] || data["full_name"]
@@ -14,6 +14,27 @@ module Brew
         @source_url = data.dig("urls", "stable", "url")
         @head_url = data.dig("urls", "head", "url")
         @dependencies = data["dependencies"] || []
+        @patches = data["patches"] || []
+      end
+
+      # CVE/GHSA identifiers declared as resolved by this formula's patches.
+      # Populated from `brew info --json=v2` `patches[].resolves[]` (Homebrew >= 6.0.4);
+      # empty on older Homebrew versions or for formulae with no annotated patches.
+      def resolved_vulnerability_ids
+        return @resolved_vulnerability_ids if defined?(@resolved_vulnerability_ids)
+
+        @resolved_vulnerability_ids = patches
+          .flat_map { |p| Array(p["resolves"]) }
+          .select { |r| r.is_a?(Hash) && r["type"] == "security" }
+          .map { |r| r["id"].to_s.upcase }
+          .uniq
+      end
+
+      def resolves?(vulnerability)
+        ids = resolved_vulnerability_ids
+        return false if ids.empty?
+
+        vulnerability.identifiers.any? { |id| ids.include?(id.to_s.upcase) }
       end
 
       def repo_url

--- a/lib/brew/vulns/vulnerability.rb
+++ b/lib/brew/vulns/vulnerability.rb
@@ -39,8 +39,12 @@ module Brew
         end
       end
 
+      def identifiers
+        ([id] + aliases).compact
+      end
+
       def cve_ids
-        ([id] + aliases).select { |a| a.start_with?("CVE-") }
+        identifiers.select { |a| a.start_with?("CVE-") }
       end
 
       def advisory_url

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -704,7 +704,7 @@ class TestCLI < Minitest::Test
     end
 
     assert_equal 0, result
-    assert_includes output, "No vulnerabilities found."
+    assert_includes output, "No open vulnerabilities found."
     assert_includes output, "2 resolved by formula patches"
     assert_includes output, "libquicktime: CVE-2016-2399, GHSA-aaaa-bbbb-cccc"
   end

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -795,7 +795,7 @@ class TestCLI < Minitest::Test
     assert_empty json[0]["patched"]
   end
 
-  def test_cyclonedx_omits_patched_vulns
+  def test_cyclonedx_marks_patched_vulns_as_resolved
     formulae = [Brew::Vulns::Formula.new(@libquicktime_data)]
     stub_libquicktime_osv
 
@@ -808,8 +808,59 @@ class TestCLI < Minitest::Test
     sbom = JSON.parse(output)
 
     assert_equal 0, result
-    assert sbom["components"].any? { |c| c["name"] == "libquicktime" }
-    assert_empty sbom["vulnerabilities"] || []
+
+    component = sbom["components"].find { |c| c["name"] == "libquicktime" }
+    patches = component["pedigree"]["patches"]
+
+    assert_equal 1, patches.size
+    assert_equal "backport", patches[0]["type"]
+    assert_equal "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz",
+                 patches[0]["diff"]["url"]
+    resolved_ids = patches[0]["resolves"].map { |r| r["id"] }
+
+    assert_includes resolved_ids, "CVE-2016-2399"
+    assert_includes resolved_ids, "CVE-2017-9122"
+
+    vulns = sbom["vulnerabilities"]
+
+    assert_equal 2, vulns.size
+    vulns.each do |v|
+      assert_equal "resolved", v["analysis"]["state"]
+      assert_equal ["update"], v["analysis"]["response"]
+      assert_match(/Resolved by Homebrew formula patch/, v["analysis"]["detail"])
+    end
+
+    ghsa = vulns.find { |v| v["id"] == "GHSA-aaaa-bbbb-cccc" }
+
+    assert_match(/CVE-2017-9122/, ghsa["analysis"]["detail"])
+  end
+
+  def test_cyclonedx_open_vulns_have_no_analysis
+    formulae = [Brew::Vulns::Formula.new(@libquicktime_data)]
+    stub_libquicktime_osv(extra_vulns: [{ "id" => "CVE-2099-9999" }])
+
+    stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2099-9999")
+      .to_return(status: 200, body: {
+        "id"                => "CVE-2099-9999",
+        "summary"           => "Unpatched issue",
+        "database_specific" => { "severity" => "HIGH" },
+      }.to_json)
+
+    output = nil
+    result = Brew::Vulns::Formula.stub :load_installed, formulae do
+      output = capture_stdout { Brew::Vulns::CLI.run(["--cyclonedx"]) }
+      Brew::Vulns::CLI.run(["--cyclonedx"])
+    end
+
+    sbom = JSON.parse(output)
+
+    assert_equal 1, result
+
+    open_vuln = sbom["vulnerabilities"].find { |v| v["id"] == "CVE-2099-9999" }
+    resolved = sbom["vulnerabilities"].find { |v| v["id"] == "CVE-2016-2399" }
+
+    refute open_vuln.key?("analysis")
+    assert_equal "resolved", resolved["analysis"]["state"]
   end
 
   def test_sarif_omits_patched_vulns

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -17,6 +17,24 @@ class TestCLI < Minitest::Test
       "versions" => { "stable" => "8.5.0" },
       "urls" => { "stable" => { "url" => "https://github.com/curl/curl/archive/refs/tags/curl-8_5_0.tar.gz" } }
     }
+    @libquicktime_data = {
+      "name"     => "libquicktime",
+      "versions" => { "stable" => "1.2.4" },
+      "urls"     => {
+        "stable" => { "url" => "https://github.com/example/libquicktime/archive/refs/tags/v1.2.4.tar.gz" },
+      },
+      "patches"  => [
+        {
+          "strip"    => "p1",
+          "url"      => "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz",
+          "type"     => "backport",
+          "resolves" => [
+            { "type" => "security", "id" => "CVE-2016-2399" },
+            { "type" => "security", "id" => "CVE-2017-9122" },
+          ],
+        },
+      ],
+    }
   end
 
   def test_help_flag_returns_zero
@@ -649,6 +667,165 @@ class TestCLI < Minitest::Test
 
     # SARIF may omit "note" level since it's not the default, but let's be permissive
     assert_includes ["note", nil], result["level"]
+  end
+
+  def stub_libquicktime_osv(extra_vulns: [])
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [{
+          vulns: [{ "id" => "CVE-2016-2399" }, { "id" => "GHSA-aaaa-bbbb-cccc" }] + extra_vulns,
+        }],
+      }.to_json)
+
+    stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2016-2399")
+      .to_return(status: 200, body: {
+        "id"                => "CVE-2016-2399",
+        "summary"           => "Heap buffer overflow",
+        "database_specific" => { "severity" => "HIGH" },
+      }.to_json)
+
+    stub_request(:get, "https://api.osv.dev/v1/vulns/GHSA-aaaa-bbbb-cccc")
+      .to_return(status: 200, body: {
+        "id"                => "GHSA-aaaa-bbbb-cccc",
+        "aliases"           => ["CVE-2017-9122"],
+        "summary"           => "DoS in quicktime_read_moov",
+        "database_specific" => { "severity" => "MEDIUM" },
+      }.to_json)
+  end
+
+  def test_suppresses_vulns_resolved_by_formula_patches
+    formulae = [Brew::Vulns::Formula.new(@libquicktime_data)]
+    stub_libquicktime_osv
+
+    output = nil
+    result = Brew::Vulns::Formula.stub :load_installed, formulae do
+      output = capture_stdout { Brew::Vulns::CLI.run([]) }
+      Brew::Vulns::CLI.run([])
+    end
+
+    assert_equal 0, result
+    assert_includes output, "No vulnerabilities found."
+    assert_includes output, "2 resolved by formula patches"
+    assert_includes output, "libquicktime: CVE-2016-2399, GHSA-aaaa-bbbb-cccc"
+  end
+
+  def test_no_ignore_patches_flag_reports_resolved_vulns
+    formulae = [Brew::Vulns::Formula.new(@libquicktime_data)]
+    stub_libquicktime_osv
+
+    output = nil
+    result = Brew::Vulns::Formula.stub :load_installed, formulae do
+      output = capture_stdout { Brew::Vulns::CLI.run(["--no-ignore-patches"]) }
+      Brew::Vulns::CLI.run(["--no-ignore-patches"])
+    end
+
+    assert_equal 1, result
+    assert_includes output, "CVE-2016-2399 (HIGH)"
+    assert_includes output, "GHSA-aaaa-bbbb-cccc (MEDIUM)"
+    refute_includes output, "resolved by formula patches"
+  end
+
+  def test_unpatched_vuln_still_reported_alongside_patched_ones
+    formulae = [Brew::Vulns::Formula.new(@libquicktime_data)]
+    stub_libquicktime_osv(extra_vulns: [{ "id" => "CVE-2024-9999" }])
+
+    stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2024-9999")
+      .to_return(status: 200, body: {
+        "id"                => "CVE-2024-9999",
+        "summary"           => "Unpatched issue",
+        "database_specific" => { "severity" => "CRITICAL" },
+      }.to_json)
+
+    output = nil
+    result = Brew::Vulns::Formula.stub :load_installed, formulae do
+      output = capture_stdout { Brew::Vulns::CLI.run([]) }
+      Brew::Vulns::CLI.run([])
+    end
+
+    assert_equal 1, result
+    assert_includes output, "CVE-2024-9999 (CRITICAL)"
+    assert_includes output, "Found 1 vulnerabilities in 1 packages"
+    assert_includes output, "2 resolved by formula patches"
+    refute_includes output, "CVE-2016-2399 (HIGH)"
+  end
+
+  def test_json_output_includes_patched_array
+    formulae = [Brew::Vulns::Formula.new(@libquicktime_data)]
+    stub_libquicktime_osv
+
+    output = nil
+    result = Brew::Vulns::Formula.stub :load_installed, formulae do
+      output = capture_stdout { Brew::Vulns::CLI.run(["--json"]) }
+      Brew::Vulns::CLI.run(["--json"])
+    end
+
+    json = JSON.parse(output)
+
+    assert_equal 0, result
+    assert_equal 1, json.size
+    assert_equal "libquicktime", json[0]["formula"]
+    assert_empty json[0]["vulnerabilities"]
+    assert_equal 2, json[0]["patched"].size
+    ids = json[0]["patched"].map { |v| v["id"] }
+    assert_includes ids, "CVE-2016-2399"
+    assert_includes ids, "GHSA-aaaa-bbbb-cccc"
+  end
+
+  def test_json_output_patched_array_empty_for_unpatched_formula
+    formulae = [Brew::Vulns::Formula.new(@vim_data)]
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: {
+        results: [{ vulns: [{ "id" => "CVE-2024-1234" }] }],
+      }.to_json)
+
+    stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2024-1234")
+      .to_return(status: 200, body: {
+        "id"                => "CVE-2024-1234",
+        "database_specific" => { "severity" => "HIGH" },
+      }.to_json)
+
+    output = Brew::Vulns::Formula.stub :load_installed, formulae do
+      capture_stdout { Brew::Vulns::CLI.run(["--json"]) }
+    end
+
+    json = JSON.parse(output)
+
+    assert_equal 1, json[0]["vulnerabilities"].size
+    assert_empty json[0]["patched"]
+  end
+
+  def test_cyclonedx_omits_patched_vulns
+    formulae = [Brew::Vulns::Formula.new(@libquicktime_data)]
+    stub_libquicktime_osv
+
+    output = nil
+    result = Brew::Vulns::Formula.stub :load_installed, formulae do
+      output = capture_stdout { Brew::Vulns::CLI.run(["--cyclonedx"]) }
+      Brew::Vulns::CLI.run(["--cyclonedx"])
+    end
+
+    sbom = JSON.parse(output)
+
+    assert_equal 0, result
+    assert sbom["components"].any? { |c| c["name"] == "libquicktime" }
+    assert_empty sbom["vulnerabilities"] || []
+  end
+
+  def test_sarif_omits_patched_vulns
+    formulae = [Brew::Vulns::Formula.new(@libquicktime_data)]
+    stub_libquicktime_osv
+
+    output = nil
+    result = Brew::Vulns::Formula.stub :load_installed, formulae do
+      output = capture_stdout { Brew::Vulns::CLI.run(["--sarif"]) }
+      Brew::Vulns::CLI.run(["--sarif"])
+    end
+
+    sarif = JSON.parse(output)
+
+    assert_equal 0, result
+    assert_equal [], sarif["runs"][0]["results"]
   end
 
   def test_all_flag_uses_load_all

--- a/test/brew/test_formula.rb
+++ b/test/brew/test_formula.rb
@@ -147,6 +147,124 @@ class TestFormula < Minitest::Test
     assert_nil formula.to_osv_query
   end
 
+  def test_resolved_vulnerability_ids_extracts_security_ids_across_patches
+    data = {
+      "name"    => "libquicktime",
+      "patches" => [
+        {
+          "strip"    => "p1",
+          "url"      => "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz",
+          "type"     => "backport",
+          "resolves" => [
+            { "type" => "security", "id" => "CVE-2016-2399" },
+            { "type" => "security", "id" => "CVE-2017-9122" },
+          ],
+        },
+        {
+          "strip"    => "p1",
+          "url"      => "https://example.com/extra.diff",
+          "resolves" => [
+            { "type" => "security", "id" => "GHSA-xr7r-f8xq-vfvv" },
+            { "type" => "security", "id" => "CVE-2017-9122" },
+          ],
+        },
+      ],
+    }
+
+    formula = Brew::Vulns::Formula.new(data)
+
+    assert_equal ["CVE-2016-2399", "CVE-2017-9122", "GHSA-XR7R-F8XQ-VFVV"], formula.resolved_vulnerability_ids
+  end
+
+  def test_resolved_vulnerability_ids_ignores_defect_resolves
+    data = {
+      "name"    => "innoextract",
+      "patches" => [
+        {
+          "strip"    => "p1",
+          "url"      => "https://github.com/dscharrer/innoextract/commit/264c2fe.patch",
+          "type"     => "backport",
+          "resolves" => [
+            { "type" => "defect", "id" => "https://github.com/dscharrer/innoextract/pull/169" },
+          ],
+        },
+      ],
+    }
+
+    formula = Brew::Vulns::Formula.new(data)
+
+    assert_empty formula.resolved_vulnerability_ids
+  end
+
+  def test_resolved_vulnerability_ids_empty_when_patches_missing
+    data = { "name" => "vim", "versions" => { "stable" => "9.1.0" } }
+
+    formula = Brew::Vulns::Formula.new(data)
+
+    assert_empty formula.patches
+    assert_empty formula.resolved_vulnerability_ids
+  end
+
+  def test_resolved_vulnerability_ids_handles_patches_without_resolves
+    data = {
+      "name"    => "gecode",
+      "patches" => [
+        { "strip" => "p1", "url" => "https://github.com/Gecode/gecode/commit/c0ca0e5.patch", "type" => "cherry-pick" },
+        { "strip" => "p1", "data" => true },
+      ],
+    }
+
+    formula = Brew::Vulns::Formula.new(data)
+
+    assert_empty formula.resolved_vulnerability_ids
+  end
+
+  def test_resolves_matches_vulnerability_id_case_insensitively
+    data = {
+      "name"    => "glibc",
+      "patches" => [
+        { "resolves" => [{ "type" => "security", "id" => "CVE-2024-2961" }] },
+      ],
+    }
+    formula = Brew::Vulns::Formula.new(data)
+    vuln = Brew::Vulns::Vulnerability.new("id" => "cve-2024-2961")
+
+    assert formula.resolves?(vuln)
+  end
+
+  def test_resolves_matches_via_vulnerability_alias
+    data = {
+      "name"    => "glibc",
+      "patches" => [
+        { "resolves" => [{ "type" => "security", "id" => "CVE-2024-2961" }] },
+      ],
+    }
+    formula = Brew::Vulns::Formula.new(data)
+    vuln = Brew::Vulns::Vulnerability.new("id" => "GHSA-aaaa-bbbb-cccc", "aliases" => ["CVE-2024-2961"])
+
+    assert formula.resolves?(vuln)
+  end
+
+  def test_resolves_returns_false_when_no_match
+    data = {
+      "name"    => "glibc",
+      "patches" => [
+        { "resolves" => [{ "type" => "security", "id" => "CVE-2024-2961" }] },
+      ],
+    }
+    formula = Brew::Vulns::Formula.new(data)
+    vuln = Brew::Vulns::Vulnerability.new("id" => "CVE-2024-9999")
+
+    refute formula.resolves?(vuln)
+  end
+
+  def test_resolves_returns_false_when_no_patches
+    formula = Brew::Vulns::Formula.new("name" => "vim")
+    vuln = Brew::Vulns::Vulnerability.new("id" => "CVE-2024-1234")
+
+    refute formula.resolves?(vuln)
+  end
+
   def test_dependencies_list
     data = {
       "name" => "vim",

--- a/test/brew/test_formula.rb
+++ b/test/brew/test_formula.rb
@@ -265,6 +265,47 @@ class TestFormula < Minitest::Test
     refute formula.resolves?(vuln)
   end
 
+  def test_cyclonedx_pedigree_maps_patch_data
+    formula = Brew::Vulns::Formula.new(
+      "name"    => "x",
+      "patches" => [
+        {
+          "url"      => "https://example.com/a.patch",
+          "type"     => "cherry_pick",
+          "resolves" => [
+            { "type" => "security", "id" => "CVE-1" },
+            { "type" => "defect", "id" => "BUG-2" },
+          ],
+        },
+        { "type" => "backport" },
+        { "url" => "https://example.com/c.patch" },
+      ],
+    )
+
+    pedigree = formula.cyclonedx_pedigree
+
+    assert_equal 3, pedigree[:patches].size
+
+    p1 = pedigree[:patches][0]
+
+    assert_equal "cherry-pick", p1[:type]
+    assert_equal "https://example.com/a.patch", p1[:diff][:url]
+    assert_equal [{ type: "security", id: "CVE-1" }, { type: "defect", id: "BUG-2" }], p1[:resolves]
+
+    p2 = pedigree[:patches][1]
+
+    assert_equal "backport", p2[:type]
+    refute p2.key?(:diff)
+    refute p2.key?(:resolves)
+
+    assert_equal "unofficial", pedigree[:patches][2][:type]
+  end
+
+  def test_cyclonedx_pedigree_nil_when_no_patches
+    assert_nil Brew::Vulns::Formula.new("name" => "x").cyclonedx_pedigree
+    assert_nil Brew::Vulns::Formula.new("name" => "x", "patches" => []).cyclonedx_pedigree
+  end
+
   def test_dependencies_list
     data = {
       "name" => "vim",

--- a/test/brew/test_formula.rb
+++ b/test/brew/test_formula.rb
@@ -176,6 +176,26 @@ class TestFormula < Minitest::Test
     assert_equal ["CVE-2016-2399", "CVE-2017-9122", "GHSA-XR7R-F8XQ-VFVV"], formula.resolved_vulnerability_ids
   end
 
+  def test_resolved_vulnerability_ids_skips_security_resolves_without_id
+    data = {
+      "name"    => "x",
+      "patches" => [
+        {
+          "resolves" => [
+            { "type" => "security" },
+            { "type" => "security", "id" => nil },
+            { "type" => "security", "id" => "" },
+            { "type" => "security", "id" => "CVE-2024-1234" },
+          ],
+        },
+      ],
+    }
+
+    formula = Brew::Vulns::Formula.new(data)
+
+    assert_equal ["CVE-2024-1234"], formula.resolved_vulnerability_ids
+  end
+
   def test_resolved_vulnerability_ids_ignores_defect_resolves
     data = {
       "name"    => "innoextract",

--- a/test/brew/test_vulnerability.rb
+++ b/test/brew/test_vulnerability.rb
@@ -251,6 +251,23 @@ class TestVulnerability < Minitest::Test
     assert_equal "HIGH", vuln.severity_display
   end
 
+  def test_identifiers_returns_id_and_aliases
+    data = {
+      "id"      => "GHSA-xxxx-yyyy-zzzz",
+      "aliases" => ["CVE-2024-1234", "OSV-2024-1"],
+    }
+
+    vuln = Brew::Vulns::Vulnerability.new(data)
+
+    assert_equal ["GHSA-xxxx-yyyy-zzzz", "CVE-2024-1234", "OSV-2024-1"], vuln.identifiers
+  end
+
+  def test_identifiers_handles_missing_aliases
+    vuln = Brew::Vulns::Vulnerability.new("id" => "CVE-2024-1234")
+
+    assert_equal ["CVE-2024-1234"], vuln.identifiers
+  end
+
   def test_cve_ids_extracts_cves_from_id_and_aliases
     data = {
       "id" => "CVE-2024-1234",


### PR DESCRIPTION
Now that Homebrew/brew#22466 has landed (Homebrew 6.0.4), `brew info --json=v2` exposes `patches[].resolves` on each formula: CVE/GHSA identifiers that a formula's applied patches fix, either declared explicitly with `resolves` or inferred from `url`/`apply`/`file` paths. This consumes that data to stop reporting those vulnerabilities as open findings.

`Formula` now reads `patches` and exposes `#resolved_vulnerability_ids` / `#resolves?(vuln)`, matching against both the OSV `id` and its `aliases` so a GHSA result that aliases a CVE the formula declares still counts. During a scan, matching results are partitioned out: text output lists them in a footer, `--json` reports them in a `patched` array per formula, `--sarif` omits them, and `--cyclonedx` includes them with `analysis.state = resolved` plus `pedigree.patches` on the component (which is what the brew DSL was modelled on). They no longer affect the exit code. `--no-ignore-patches` restores the old behaviour.

The CycloneDX output requires `sbom` ~> 0.5, which now passes `analysis` and `pedigree` through instead of stripping them.

Test fixtures mirror the `libquicktime`/`glibc`/`innoextract`/`gecode` examples from Homebrew/homebrew-core#285534. The inferred `resolves` for `glibc` is already populated in live `brew info` output on 6.0.4, so the shape is verified against real data even before the homebrew-core annotations land.

Refs https://github.com/orgs/Homebrew/discussions/6869
