### PR TITLE
Query OSV for formulae outside GitHub/GitLab/Codeberg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 
-- Query OSV for formulae whose source is not on GitHub/GitLab/Codeberg by falling back to the formula's `head` git URL (or a `tag:`-style stable git URL) and the bare formula version. Removes the forge whitelist; any formula with a derivable git repository URL is now sent in the batch query
+- Query OSV for formulae whose source is not on GitHub/GitLab/Codeberg by falling back to the formula's `head` git URL, a `tag:`-style stable git URL, or a forge URL in `homepage`, with the bare formula version. Removes the forge whitelist; any formula with a derivable git repository URL is now sent in the batch query
 
 ## [0.4.0] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Query OSV for formulae whose source is not on GitHub/GitLab/Codeberg by falling back to the formula's `head` git URL (or a `tag:`-style stable git URL) and the bare formula version. Removes the forge whitelist; any formula with a derivable git repository URL is now sent in the batch query
+
 ## [0.4.0] - 2026-06-28
 
 - Suppress vulnerabilities that a formula's patches declare as resolved (via `patches[].resolves` in `brew info --json=v2`, Homebrew 6.0.4+); list them separately in text/JSON output, exclude them from SARIF output, and exclude them from the exit code

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ brew vulns --help
 ## How it works
 
 1. Reads Homebrew formulae via `brew info --json=v2` (installed packages by default, or any named formulae passed as arguments)
-2. Extracts the repository URL and version tag from each formula's source URL
+2. Derives a git repository URL for each formula from its stable source URL, `head` URL or homepage, and a version from the release tag or formula version
 3. Queries the OSV API using the GIT ecosystem to find known vulnerabilities
 4. Reports any vulnerabilities found with their severity and CVE identifiers
 
-Packages with GitHub, GitLab, or Codeberg source URLs are checked. Packages from other sources are skipped.
+A formula is queried when a repository URL can be derived. GitHub, GitLab and Codeberg URLs are recognised in any of the stable, `head` or homepage fields; for other hosts, the `head` URL or a `tag:`-style stable git URL is used as-is. Formulae with none of these are skipped.
 
 ### Patched vulnerabilities
 
@@ -106,8 +106,8 @@ This relies on `patches[].resolves` data in `brew info --json=v2`, available fro
 ## Example output
 
 ```
-Checking 104 packages for vulnerabilities...
-(119 packages skipped - no supported source URL)
+Checking 181 packages for vulnerabilities...
+(42 packages skipped - no source repository URL or version)
 
 expat (2.7.3)
   CVE-2025-66382 (HIGH) - XML parsing vulnerability...

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -101,7 +101,7 @@ module Brew
 
         unless @json_output || @sarif_output || @cyclonedx_output
           puts "Checking #{queryable.size} packages for vulnerabilities..."
-          puts "(#{skipped} packages skipped - no source repository URL)" if skipped > 0
+          puts "(#{skipped} packages skipped - no source repository URL or version)" if skipped > 0
           puts
         end
 

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -96,12 +96,12 @@ module Brew
           return 0
         end
 
-        queryable = formulae.select(&:supported_forge?).select(&:tag)
+        queryable = formulae.select(&:to_osv_query)
         skipped = formulae.size - queryable.size
 
         unless @json_output || @sarif_output || @cyclonedx_output
           puts "Checking #{queryable.size} packages for vulnerabilities..."
-          puts "(#{skipped} packages skipped - no supported source URL)" if skipped > 0
+          puts "(#{skipped} packages skipped - no source repository URL)" if skipped > 0
           puts
         end
 

--- a/lib/brew/vulns/formula.rb
+++ b/lib/brew/vulns/formula.rb
@@ -6,7 +6,7 @@ require "open3"
 module Brew
   module Vulns
     class Formula
-      attr_reader :name, :version, :source_url, :head_url, :dependencies, :patches
+      attr_reader :name, :version, :source_url, :head_url, :homepage, :dependencies, :patches
 
       def initialize(data)
         @name = data["name"] || data["full_name"]
@@ -14,6 +14,7 @@ module Brew
         @source_url = data.dig("urls", "stable", "url")
         @stable_tag = data.dig("urls", "stable", "tag")
         @head_url = data.dig("urls", "head", "url")
+        @homepage = data["homepage"]
         @dependencies = data["dependencies"] || []
         @patches = data["patches"] || []
       end
@@ -69,18 +70,18 @@ module Brew
 
       # The git repository URL to use as the OSV `GIT` ecosystem package name.
       # In order of preference:
-      #   1. owner/repo extracted from a recognised forge URL on stable, then head.
-      #      Known forges are preferred even when head is a mirror of a non-forge
-      #      stable repo, because OSV's GIT coverage is much better for them.
+      #   1. owner/repo extracted from a recognised forge URL on stable, head,
+      #      or homepage. Known forges are preferred even over a canonical
+      #      non-forge git URL, because OSV's GIT coverage is much better there.
       #   2. the stable URL itself when stable is a git checkout (`url ..., tag: ...`)
       #   3. the head URL verbatim (head specs are always git URLs)
-      # Returns nil for formulae with no recognised forge URL, no `tag:` stable
-      # spec and no head spec.
+      # Returns nil when none of the above yield a URL.
       def repo_url
         return @repo_url if defined?(@repo_url)
 
         @repo_url = extract_repo_url(source_url) ||
                     extract_repo_url(head_url) ||
+                    extract_repo_url(homepage) ||
                     (source_url if @stable_tag) ||
                     head_url
       end

--- a/lib/brew/vulns/formula.rb
+++ b/lib/brew/vulns/formula.rb
@@ -69,10 +69,13 @@ module Brew
 
       # The git repository URL to use as the OSV `GIT` ecosystem package name.
       # In order of preference:
-      #   1. owner/repo extracted from a recognised forge tarball URL (stable, then head)
+      #   1. owner/repo extracted from a recognised forge URL on stable, then head.
+      #      Known forges are preferred even when head is a mirror of a non-forge
+      #      stable repo, because OSV's GIT coverage is much better for them.
       #   2. the stable URL itself when stable is a git checkout (`url ..., tag: ...`)
       #   3. the head URL verbatim (head specs are always git URLs)
-      # Returns nil for formulae with neither a forge tarball nor a head spec.
+      # Returns nil for formulae with no recognised forge URL, no `tag:` stable
+      # spec and no head spec.
       def repo_url
         return @repo_url if defined?(@repo_url)
 

--- a/lib/brew/vulns/formula.rb
+++ b/lib/brew/vulns/formula.rb
@@ -12,6 +12,7 @@ module Brew
         @name = data["name"] || data["full_name"]
         @version = data.dig("versions", "stable") || data["version"]
         @source_url = data.dig("urls", "stable", "url")
+        @stable_tag = data.dig("urls", "stable", "tag")
         @head_url = data.dig("urls", "head", "url")
         @dependencies = data["dependencies"] || []
         @patches = data["patches"] || []
@@ -66,32 +67,29 @@ module Brew
         { patches: cdx_patches }
       end
 
+      # The git repository URL to use as the OSV `GIT` ecosystem package name.
+      # In order of preference:
+      #   1. owner/repo extracted from a recognised forge tarball URL (stable, then head)
+      #   2. the stable URL itself when stable is a git checkout (`url ..., tag: ...`)
+      #   3. the head URL verbatim (head specs are always git URLs)
+      # Returns nil for formulae with neither a forge tarball nor a head spec.
       def repo_url
         return @repo_url if defined?(@repo_url)
 
-        @repo_url = extract_repo_url(source_url) || extract_repo_url(head_url)
+        @repo_url = extract_repo_url(source_url) ||
+                    extract_repo_url(head_url) ||
+                    (source_url if @stable_tag) ||
+                    head_url
       end
 
+      # The version identifier to send as the OSV query `version`. Prefers an
+      # explicit git tag (from a `tag:` stable spec or parsed from a forge
+      # tarball URL); falls back to the bare formula version, which OSV's GIT
+      # ecosystem accepts for at least some upstreams.
       def tag
         return @tag if defined?(@tag)
 
-        @tag = extract_tag_from_url(source_url)
-      end
-
-      def github?
-        repo_url&.include?("github.com")
-      end
-
-      def gitlab?
-        repo_url&.include?("gitlab.com")
-      end
-
-      def codeberg?
-        repo_url&.include?("codeberg.org")
-      end
-
-      def supported_forge?
-        github? || gitlab? || codeberg?
+        @tag = @stable_tag || extract_tag_from_url(source_url) || version
       end
 
       def to_osv_query

--- a/test/brew/test_formula.rb
+++ b/test/brew/test_formula.rb
@@ -18,7 +18,6 @@ class TestFormula < Minitest::Test
 
     assert_equal "https://github.com/nektos/act", formula.repo_url
     assert_equal "v0.2.84", formula.tag
-    assert formula.github?
   end
 
   def test_extracts_tag_without_v_prefix
@@ -66,20 +65,19 @@ class TestFormula < Minitest::Test
     assert_equal "https://github.com/AomediaOrg/aom", formula.repo_url
   end
 
-  def test_returns_nil_for_unsupported_urls
+  def test_repo_url_nil_for_non_forge_tarball_without_head
     data = {
-      "name" => "example",
-      "versions" => { "stable" => "1.0.0" },
+      "name" => "libquicktime",
+      "versions" => { "stable" => "1.2.4" },
       "urls" => {
-        "stable" => { "url" => "https://example.com/source.tar.gz" }
+        "stable" => { "url" => "https://downloads.sourceforge.net/project/libquicktime/libquicktime/1.2.4/libquicktime-1.2.4.tar.gz" }
       }
     }
 
     formula = Brew::Vulns::Formula.new(data)
 
     assert_nil formula.repo_url
-    refute formula.github?
-    refute formula.supported_forge?
+    assert_nil formula.to_osv_query
   end
 
   def test_extracts_repo_url_from_gitlab_archive_url
@@ -94,9 +92,6 @@ class TestFormula < Minitest::Test
     formula = Brew::Vulns::Formula.new(data)
 
     assert_equal "https://gitlab.com/owner/repo", formula.repo_url
-    assert formula.gitlab?
-    assert formula.supported_forge?
-    refute formula.github?
   end
 
   def test_extracts_repo_url_from_codeberg_archive_url
@@ -111,9 +106,56 @@ class TestFormula < Minitest::Test
     formula = Brew::Vulns::Formula.new(data)
 
     assert_equal "https://codeberg.org/owner/repo", formula.repo_url
-    assert formula.codeberg?
-    assert formula.supported_forge?
-    refute formula.github?
+  end
+
+  def test_uses_stable_git_url_and_tag_for_non_forge_host
+    data = {
+      "name" => "aom",
+      "versions" => { "stable" => "3.14.1" },
+      "urls" => {
+        "stable" => { "url" => "https://aomedia.googlesource.com/aom.git", "tag" => "v3.14.1" }
+      }
+    }
+
+    formula = Brew::Vulns::Formula.new(data)
+
+    assert_equal "https://aomedia.googlesource.com/aom.git", formula.repo_url
+    assert_equal "v3.14.1", formula.tag
+    assert_equal({ repo_url: "https://aomedia.googlesource.com/aom.git", version: "v3.14.1", name: "aom" },
+                 formula.to_osv_query)
+  end
+
+  def test_prefers_explicit_stable_tag_over_url_parsing
+    data = {
+      "name" => "argo",
+      "versions" => { "stable" => "4.0.6" },
+      "urls" => {
+        "stable" => { "url" => "https://github.com/argoproj/argo-workflows.git", "tag" => "v4.0.6" }
+      }
+    }
+
+    formula = Brew::Vulns::Formula.new(data)
+
+    assert_equal "https://github.com/argoproj/argo-workflows", formula.repo_url
+    assert_equal "v4.0.6", formula.tag
+  end
+
+  def test_falls_back_to_head_url_and_version_for_non_forge_tarball
+    data = {
+      "name" => "coreutils",
+      "versions" => { "stable" => "9.11" },
+      "urls" => {
+        "stable" => { "url" => "https://ftpmirror.gnu.org/gnu/coreutils/coreutils-9.11.tar.xz" },
+        "head" => { "url" => "https://git.savannah.gnu.org/git/coreutils.git" }
+      }
+    }
+
+    formula = Brew::Vulns::Formula.new(data)
+
+    assert_equal "https://git.savannah.gnu.org/git/coreutils.git", formula.repo_url
+    assert_equal "9.11", formula.tag
+    assert_equal({ repo_url: "https://git.savannah.gnu.org/git/coreutils.git", version: "9.11", name: "coreutils" },
+                 formula.to_osv_query)
   end
 
   def test_to_osv_query_returns_hash_with_required_fields
@@ -133,17 +175,18 @@ class TestFormula < Minitest::Test
     assert_equal "vim", query[:name]
   end
 
-  def test_to_osv_query_returns_nil_when_no_repo_url
+  def test_to_osv_query_returns_nil_when_head_url_but_no_version
     data = {
       "name" => "example",
-      "versions" => { "stable" => "1.0.0" },
       "urls" => {
-        "stable" => { "url" => "https://example.com/source.tar.gz" }
+        "head" => { "url" => "https://git.example.com/repo.git" }
       }
     }
 
     formula = Brew::Vulns::Formula.new(data)
 
+    assert_equal "https://git.example.com/repo.git", formula.repo_url
+    assert_nil formula.tag
     assert_nil formula.to_osv_query
   end
 

--- a/test/brew/test_formula.rb
+++ b/test/brew/test_formula.rb
@@ -140,6 +140,37 @@ class TestFormula < Minitest::Test
     assert_equal "v4.0.6", formula.tag
   end
 
+  def test_falls_back_to_forge_homepage_for_non_forge_tarball
+    data = {
+      "name" => "util-linux",
+      "homepage" => "https://github.com/util-linux/util-linux",
+      "versions" => { "stable" => "2.42.2" },
+      "urls" => {
+        "stable" => { "url" => "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.42/util-linux-2.42.2.tar.xz" }
+      }
+    }
+
+    formula = Brew::Vulns::Formula.new(data)
+
+    assert_equal "https://github.com/util-linux/util-linux", formula.repo_url
+    assert_equal "2.42.2", formula.tag
+  end
+
+  def test_ignores_non_forge_homepage
+    data = {
+      "name" => "glib",
+      "homepage" => "https://docs.gtk.org/glib/",
+      "versions" => { "stable" => "2.88.2" },
+      "urls" => {
+        "stable" => { "url" => "https://download.gnome.org/sources/glib/2.88/glib-2.88.2.tar.xz" }
+      }
+    }
+
+    formula = Brew::Vulns::Formula.new(data)
+
+    assert_nil formula.repo_url
+  end
+
   def test_falls_back_to_head_url_and_version_for_non_forge_tarball
     data = {
       "name" => "coreutils",


### PR DESCRIPTION
Drops the forge whitelist in `Formula` and lets any derived repo URL through to the OSV batch query. When the stable URL is not a recognised forge tarball, fall back to the stable URL itself for `tag:`-style git checkouts, then to the formula's `head` URL.

For the query version, prefer an explicit `urls.stable.tag` when present and otherwise fall back to the bare formula version. OSV's GIT ecosystem matches at least some upstreams on bare versions, e.g. `{name: "https://sourceware.org/git/glibc.git", version: "2.39"}` returns CVE-2025-15281.

Against current homebrew-core this raises queryable formulae from 4948 to 6293. Coverage outside the big forges is thin so most of the new queries will return nothing, but the batch call costs the same either way.

Removes the now-unused `github?`/`gitlab?`/`codeberg?`/`supported_forge?` predicates.

As noted in the issue, formulae with neither a forge tarball nor a `head` block (e.g. `glibc`, `libquicktime`) are still skipped; adding `head` to those is a homebrew-core change.

Fixes #93