### PR TITLE
Add --osv-export to emit Homebrew-ecosystem OSV records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Query OSV for formulae whose source is not on GitHub/GitLab/Codeberg by falling back to the formula's `head` git URL, a `tag:`-style stable git URL, or a forge URL in `homepage`, with the bare formula version. Removes the forge whitelist; any formula with a derivable git repository URL is now sent in the batch query
 - CycloneDX output: percent-encode `@` in `pkg:brew/` purls so versioned formula names like `glibc@2.13` are not misparsed as `name@version`
+- Add `--osv-export DIR` (experimental) to write OSV-schema records under a `Homebrew` ecosystem for every CVE listed in a formula's `patches[].resolves`. Each record marks the formula as fixed at the currently shipped version+revision and carries the resolving patch detail in `ecosystem_specific`. Intended as the seed for a published Homebrew advisory feed.
 
 ## [0.4.0] - 2026-06-28
 

--- a/lib/brew/vulns.rb
+++ b/lib/brew/vulns.rb
@@ -7,6 +7,7 @@ require_relative "vulns/version"
 require_relative "vulns/osv_client"
 require_relative "vulns/formula"
 require_relative "vulns/vulnerability"
+require_relative "vulns/osv_export"
 require_relative "vulns/cli"
 
 module Brew

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -10,7 +10,7 @@ module Brew
       DEFAULT_MAX_SUMMARY = 60
       SEVERITY_LEVELS = { "low" => 1, "medium" => 2, "high" => 3, "critical" => 4 }.freeze
       MAX_VULN_FETCH_THREADS = 15
-      FLAGS_WITH_VALUE = %w[-b --brewfile -m --max-summary -s --severity].freeze
+      FLAGS_WITH_VALUE = %w[-b --brewfile -m --max-summary -s --severity --osv-export].freeze
 
       def initialize(args)
         @args = args
@@ -25,6 +25,7 @@ module Brew
         @max_summary = parse_max_summary(args)
         @min_severity = parse_severity(args)
         @brewfile = parse_brewfile_path(args)
+        @osv_export_dir = parse_osv_export_dir(args)
       end
 
       def parse_formula_names(args)
@@ -71,6 +72,19 @@ module Brew
         0
       end
 
+      def parse_osv_export_dir(args)
+        args.each_with_index do |arg, idx|
+          if arg == "--osv-export"
+            value = args[idx + 1]
+            return value if value && !value.start_with?("-")
+            return "osv-export"
+          elsif arg.start_with?("--osv-export=")
+            return arg.split("=", 2).last
+          end
+        end
+        nil
+      end
+
       def parse_brewfile_path(args)
         args.each_with_index do |arg, idx|
           if arg == "--brewfile" || arg == "-b"
@@ -89,6 +103,8 @@ module Brew
           print_help
           return 0
         end
+
+        return run_osv_export if @osv_export_dir
 
         formulae = load_formulae
         if formulae.empty?
@@ -115,6 +131,25 @@ module Brew
         2
       rescue JSON::ParserError => e
         $stderr.puts "Error parsing brew output: #{e.message}"
+        2
+      end
+
+      def run_osv_export
+        formulae = if @formula_names.any?
+          Formula.load_named(@formula_names)
+        else
+          Formula.load_all
+        end
+
+        annotated = formulae.select { |f| f.resolved_vulnerability_ids.any? }
+        $stderr.puts "#{annotated.size} formulae with security `resolves` annotations"
+
+        written = OsvExport.run(annotated, @osv_export_dir)
+        written.each { |p| $stderr.puts "  wrote #{p}" }
+        $stderr.puts "#{written.size} records written to #{@osv_export_dir}"
+        0
+      rescue Error => e
+        $stderr.puts "Error: #{e.message}"
         2
       end
 
@@ -421,6 +456,7 @@ module Brew
             -j, --json           Output results as JSON
             --cyclonedx          Output results as CycloneDX SBOM with vulnerabilities
             --sarif              Output results as SARIF for GitHub code scanning
+            --osv-export DIR     Write OSV-schema records for patch-resolved CVEs to DIR (experimental)
             -m, --max-summary N  Truncate summaries to N characters (default: 60, 0 for no limit)
             -s, --severity LEVEL Only show vulnerabilities at or above LEVEL (low, medium, high, critical)
             -h, --help           Show this help message
@@ -438,6 +474,7 @@ module Brew
             brew vulns --cyclonedx        Output as CycloneDX SBOM
             brew vulns --sarif            Output as SARIF for GitHub Actions
             brew vulns --severity high    Only show HIGH and CRITICAL vulnerabilities
+            brew vulns --osv-export ./advisories  Generate Homebrew-ecosystem OSV records
         HELP
       end
     end

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -5,6 +5,9 @@ module Brew
     class CLI
       def self.run(args)
         new(args).run
+      rescue Error => e
+        $stderr.puts "Error: #{e.message}"
+        2
       end
 
       DEFAULT_MAX_SUMMARY = 60
@@ -76,10 +79,14 @@ module Brew
         args.each_with_index do |arg, idx|
           if arg == "--osv-export"
             value = args[idx + 1]
-            return value if value && !value.start_with?("-")
-            return "osv-export"
+            return value if value && !value.empty? && !value.start_with?("-")
+
+            raise Error, "--osv-export requires a directory argument"
           elsif arg.start_with?("--osv-export=")
-            return arg.split("=", 2).last
+            value = arg.split("=", 2).last
+            raise Error, "--osv-export requires a directory argument" if value.empty?
+
+            return value
           end
         end
         nil
@@ -134,6 +141,9 @@ module Brew
         2
       end
 
+      # OSV export always operates on the full homebrew-core set (it generates
+      # an ecosystem-wide advisory feed), or on explicitly named formulae for
+      # testing. --brewfile / installed selection are intentionally ignored.
       def run_osv_export
         formulae = if @formula_names.any?
           Formula.load_named(@formula_names)

--- a/lib/brew/vulns/formula.rb
+++ b/lib/brew/vulns/formula.rb
@@ -7,11 +7,12 @@ require "purl"
 module Brew
   module Vulns
     class Formula
-      attr_reader :name, :version, :source_url, :head_url, :homepage, :dependencies, :patches
+      attr_reader :name, :version, :revision, :source_url, :head_url, :homepage, :dependencies, :patches
 
       def initialize(data)
         @name = data["name"] || data["full_name"]
         @version = data.dig("versions", "stable") || data["version"]
+        @revision = data["revision"].to_i
         @source_url = data.dig("urls", "stable", "url")
         @stable_tag = data.dig("urls", "stable", "tag")
         @head_url = data.dig("urls", "head", "url")
@@ -20,12 +21,26 @@ module Brew
         @patches = data["patches"] || []
       end
 
+      # The Homebrew package version including the revision suffix, e.g. "1.81.6_6".
+      # This is the version string as it appears in `pkg:brew/` purls and bottle paths.
+      def full_version
+        revision.zero? ? version : "#{version}_#{revision}"
+      end
+
       # Package URL for this formula. Uses the `purl` gem so that special
       # characters in the formula name (notably `@` in versioned formulae like
       # `glibc@2.13`) are percent-encoded; otherwise the `@` would be parsed as
       # the version separator.
       def purl(with_version: true)
         Purl::PackageURL.new(type: "brew", name: name, version: with_version ? version : nil).to_s
+      end
+
+      # Patches whose `resolves` list contains `vuln_id` (case-insensitive).
+      def patches_resolving(vuln_id)
+        target = vuln_id.to_s.upcase
+        patches.select do |p|
+          Array(p["resolves"]).any? { |r| r.is_a?(Hash) && r["type"] == "security" && r["id"].to_s.upcase == target }
+        end
       end
 
       # CVE/GHSA identifiers declared as resolved by this formula's patches.

--- a/lib/brew/vulns/osv_export.rb
+++ b/lib/brew/vulns/osv_export.rb
@@ -21,7 +21,7 @@ module Brew
     module OsvExport
       SCHEMA_VERSION = "1.7.3"
       ECOSYSTEM = "Homebrew"
-      ID_PREFIX = "HOMEBREW"
+      ID_PREFIX = "BREW"
 
       module_function
 

--- a/lib/brew/vulns/osv_export.rb
+++ b/lib/brew/vulns/osv_export.rb
@@ -71,7 +71,7 @@ module Brew
           package: {
             ecosystem: ECOSYSTEM,
             name:      formula.name,
-            purl:      "pkg:brew/#{formula.name}",
+            purl:      formula.purl(with_version: false),
           },
           ranges: [
             {

--- a/lib/brew/vulns/osv_export.rb
+++ b/lib/brew/vulns/osv_export.rb
@@ -84,7 +84,7 @@ module Brew
           ],
           ecosystem_specific: {
             fix:     "patch",
-            patches: formula.patches_resolving(vuln_id).map { |p| patch_ref(p) },
+            patches: formula.patches_resolving(vuln_id).filter_map { |p| patch_ref(p) },
           },
         }
       end
@@ -93,8 +93,10 @@ module Brew
         ref = {}
         ref[:type] = patch["type"] if patch["type"]
         ref[:url] = patch["url"] if patch["url"]
+        ref[:file] = patch["file"] if patch["file"]
         ref[:apply] = patch["apply"] if patch["apply"]
-        ref
+        ref[:data] = true if patch["data"]
+        ref.empty? ? nil : ref
       end
 
       def fetch_upstream(client, vuln_id)

--- a/lib/brew/vulns/osv_export.rb
+++ b/lib/brew/vulns/osv_export.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "json"
+require "time"
+require "fileutils"
+
+module Brew
+  module Vulns
+    # Emits OSV-schema records for a `Homebrew` ecosystem describing CVEs that
+    # homebrew-core formulae resolve via shipped patches.
+    #
+    # One record is written per (formula, vulnerability id) pair found in
+    # `patches[].resolves`. The record states that the formula was affected up
+    # to (but not including) the currently shipped version+revision; this is the
+    # "fixed at or before what we ship today" approximation, since the precise
+    # fix boundary requires homebrew-core git archaeology.
+    #
+    # Record shape follows the OSV 1.7 schema and mirrors the Debian DSA layout
+    # (`upstream` listing the source CVE, `affected[].ranges` of type
+    # `ECOSYSTEM`, `ecosystem_specific` carrying the patch detail).
+    module OsvExport
+      SCHEMA_VERSION = "1.7.3"
+      ECOSYSTEM = "Homebrew"
+      ID_PREFIX = "HOMEBREW"
+
+      module_function
+
+      def run(formulae, dir, client: OsvClient.new, now: Time.now.utc)
+        FileUtils.mkdir_p(dir)
+        written = []
+
+        formulae.each do |formula|
+          formula.resolved_vulnerability_ids.each do |vuln_id|
+            upstream = fetch_upstream(client, vuln_id)
+            record = record_for(formula, vuln_id, upstream: upstream, now: now)
+            path = File.join(dir, "#{record[:id]}.json")
+            File.write(path, JSON.pretty_generate(record))
+            written << path
+          end
+        end
+
+        written
+      end
+
+      def record_for(formula, vuln_id, upstream: nil, now: Time.now.utc)
+        record = {
+          schema_version: SCHEMA_VERSION,
+          id:             record_id(formula, vuln_id),
+          modified:       now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+          upstream:       [vuln_id],
+          affected:       [affected_entry(formula, vuln_id)],
+        }
+
+        if upstream
+          record[:summary] = upstream["summary"] if upstream["summary"]
+          record[:details] = upstream["details"] if upstream["details"]
+          record[:severity] = upstream["severity"] if upstream["severity"]
+          record[:upstream] = ([vuln_id] + Array(upstream["aliases"])).uniq
+          record[:references] = upstream["references"] if upstream["references"]
+        end
+
+        record
+      end
+
+      def record_id(formula, vuln_id)
+        "#{ID_PREFIX}-#{formula.name}-#{vuln_id}"
+      end
+
+      def affected_entry(formula, vuln_id)
+        {
+          package: {
+            ecosystem: ECOSYSTEM,
+            name:      formula.name,
+            purl:      "pkg:brew/#{formula.name}",
+          },
+          ranges: [
+            {
+              type:   "ECOSYSTEM",
+              events: [
+                { introduced: "0" },
+                { fixed: formula.full_version },
+              ],
+            },
+          ],
+          ecosystem_specific: {
+            fix:     "patch",
+            patches: formula.patches_resolving(vuln_id).map { |p| patch_ref(p) },
+          },
+        }
+      end
+
+      def patch_ref(patch)
+        ref = {}
+        ref[:type] = patch["type"] if patch["type"]
+        ref[:url] = patch["url"] if patch["url"]
+        ref[:apply] = patch["apply"] if patch["apply"]
+        ref
+      end
+
+      def fetch_upstream(client, vuln_id)
+        client.get_vulnerability(vuln_id)
+      rescue OsvClient::Error
+        nil
+      end
+    end
+  end
+end

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -144,6 +144,42 @@ class TestCLI < Minitest::Test
     end
   end
 
+  def test_osv_export_flag_runs_over_all_formulae_by_default
+    libqt = Brew::Vulns::Formula.new(@libquicktime_data)
+    vim = Brew::Vulns::Formula.new(@vim_data)
+
+    export_args = nil
+    Brew::Vulns::Formula.stub :load_all, [libqt, vim] do
+      Brew::Vulns::OsvExport.stub :run, ->(formulae, dir, **) { export_args = [formulae, dir]; [] } do
+        result = Brew::Vulns::CLI.run(["--osv-export", "/tmp/out"])
+
+        assert_equal 0, result
+      end
+    end
+
+    refute_nil export_args
+    assert_equal [libqt], export_args[0]
+    assert_equal "/tmp/out", export_args[1]
+  end
+
+  def test_osv_export_flag_with_named_formulae
+    libqt = Brew::Vulns::Formula.new(@libquicktime_data)
+
+    Brew::Vulns::Formula.stub :load_named, ->(names, **) { assert_equal ["libquicktime"], names; [libqt] } do
+      Brew::Vulns::OsvExport.stub :run, ->(*) { [] } do
+        result = Brew::Vulns::CLI.run(["--osv-export=/tmp/out", "libquicktime"])
+
+        assert_equal 0, result
+      end
+    end
+  end
+
+  def test_osv_export_flag_requires_dir
+    assert_equal 2, Brew::Vulns::CLI.run(["--osv-export"])
+    assert_equal 2, Brew::Vulns::CLI.run(["--osv-export="])
+    assert_equal 2, Brew::Vulns::CLI.run(["--osv-export", "--json"])
+  end
+
   def test_load_error_returns_two
     Brew::Vulns::Formula.stub :load_installed, ->(*) { raise Brew::Vulns::Error, "boom" } do
       result = Brew::Vulns::CLI.run([])

--- a/test/brew/test_osv_export.rb
+++ b/test/brew/test_osv_export.rb
@@ -28,7 +28,7 @@ class TestOsvExport < Minitest::Test
     record = Brew::Vulns::OsvExport.record_for(nvi_formula, "CVE-2015-2305", now: NOW)
 
     assert_equal "1.7.3", record[:schema_version]
-    assert_equal "HOMEBREW-nvi-CVE-2015-2305", record[:id]
+    assert_equal "BREW-nvi-CVE-2015-2305", record[:id]
     assert_equal "2026-06-28T12:00:00Z", record[:modified]
     assert_equal ["CVE-2015-2305"], record[:upstream]
     refute record.key?(:summary)
@@ -131,9 +131,9 @@ class TestOsvExport < Minitest::Test
 
       filenames = written.map { |p| File.basename(p) }.sort
       expected = [
-        "HOMEBREW-libquicktime-CVE-2016-2399.json",
-        "HOMEBREW-libquicktime-CVE-2017-9122.json",
-        "HOMEBREW-nvi-CVE-2015-2305.json",
+        "BREW-libquicktime-CVE-2016-2399.json",
+        "BREW-libquicktime-CVE-2017-9122.json",
+        "BREW-nvi-CVE-2015-2305.json",
       ]
 
       assert_equal expected, filenames

--- a/test/brew/test_osv_export.rb
+++ b/test/brew/test_osv_export.rb
@@ -49,6 +49,23 @@ class TestOsvExport < Minitest::Test
     assert_equal({ fixed: "1.81.6_6" }, events[1])
   end
 
+  def test_patch_ref_includes_file_and_data_and_drops_empty
+    formula = Brew::Vulns::Formula.new(
+      "name"     => "x",
+      "versions" => { "stable" => "1.0" },
+      "patches"  => [
+        { "file" => "Patches/x/fix.patch", "resolves" => [{ "type" => "security", "id" => "CVE-1" }] },
+        { "data" => true, "resolves" => [{ "type" => "security", "id" => "CVE-1" }] },
+        { "resolves" => [{ "type" => "security", "id" => "CVE-1" }] },
+      ],
+    )
+
+    patches = Brew::Vulns::OsvExport.record_for(formula, "CVE-1", now: NOW)
+                                    .dig(:affected, 0, :ecosystem_specific, :patches)
+
+    assert_equal [{ file: "Patches/x/fix.patch" }, { data: true }], patches
+  end
+
   def test_record_for_ecosystem_specific_lists_only_resolving_patches
     record = Brew::Vulns::OsvExport.record_for(nvi_formula, "CVE-2015-2305", now: NOW)
     eco = record[:affected].first[:ecosystem_specific]

--- a/test/brew/test_osv_export.rb
+++ b/test/brew/test_osv_export.rb
@@ -95,6 +95,19 @@ class TestOsvExport < Minitest::Test
     assert_equal upstream["references"], record[:references]
   end
 
+  def test_record_for_encodes_at_in_formula_name_purl
+    formula = Brew::Vulns::Formula.new(
+      "name"     => "glibc@2.13",
+      "versions" => { "stable" => "2.13" },
+      "patches"  => [{ "resolves" => [{ "type" => "security", "id" => "CVE-2024-2961" }] }],
+    )
+
+    record = Brew::Vulns::OsvExport.record_for(formula, "CVE-2024-2961", now: NOW)
+
+    assert_equal "pkg:brew/glibc%402.13", record[:affected][0][:package][:purl]
+    assert_equal "glibc@2.13", record[:affected][0][:package][:name]
+  end
+
   def test_full_version_without_revision
     formula = Brew::Vulns::Formula.new("name" => "x", "versions" => { "stable" => "1.0" }, "revision" => 0)
 

--- a/test/brew/test_osv_export.rb
+++ b/test/brew/test_osv_export.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+class TestOsvExport < Minitest::Test
+  NOW = Time.utc(2026, 6, 28, 12, 0, 0)
+
+  def nvi_formula
+    Brew::Vulns::Formula.new(
+      "name"     => "nvi",
+      "versions" => { "stable" => "1.81.6" },
+      "revision" => 6,
+      "patches"  => [
+        { "strip" => "p0", "file" => "Patches/nvi/patch-common__db.h" },
+        {
+          "strip"    => "p1",
+          "url"      => "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6-17.debian.tar.xz",
+          "type"     => "backport",
+          "apply"    => ["patches/31regex_heap_overflow.patch"],
+          "resolves" => [{ "type" => "security", "id" => "CVE-2015-2305" }],
+        },
+      ],
+    )
+  end
+
+  def test_record_for_builds_minimal_record_without_upstream
+    record = Brew::Vulns::OsvExport.record_for(nvi_formula, "CVE-2015-2305", now: NOW)
+
+    assert_equal "1.7.3", record[:schema_version]
+    assert_equal "HOMEBREW-nvi-CVE-2015-2305", record[:id]
+    assert_equal "2026-06-28T12:00:00Z", record[:modified]
+    assert_equal ["CVE-2015-2305"], record[:upstream]
+    refute record.key?(:summary)
+    refute record.key?(:references)
+  end
+
+  def test_record_for_affected_package_and_range
+    record = Brew::Vulns::OsvExport.record_for(nvi_formula, "CVE-2015-2305", now: NOW)
+    affected = record[:affected].first
+
+    assert_equal "Homebrew", affected[:package][:ecosystem]
+    assert_equal "nvi", affected[:package][:name]
+    assert_equal "pkg:brew/nvi", affected[:package][:purl]
+
+    events = affected[:ranges].first[:events]
+
+    assert_equal({ introduced: "0" }, events[0])
+    assert_equal({ fixed: "1.81.6_6" }, events[1])
+  end
+
+  def test_record_for_ecosystem_specific_lists_only_resolving_patches
+    record = Brew::Vulns::OsvExport.record_for(nvi_formula, "CVE-2015-2305", now: NOW)
+    eco = record[:affected].first[:ecosystem_specific]
+
+    assert_equal "patch", eco[:fix]
+    assert_equal 1, eco[:patches].size
+    assert_equal "backport", eco[:patches][0][:type]
+    assert_equal "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6-17.debian.tar.xz", eco[:patches][0][:url]
+    assert_equal ["patches/31regex_heap_overflow.patch"], eco[:patches][0][:apply]
+  end
+
+  def test_record_for_merges_upstream_data
+    upstream = {
+      "summary"    => "Integer overflow in regcomp",
+      "details"    => "Long description.",
+      "aliases"    => ["GHSA-aaaa-bbbb-cccc"],
+      "severity"   => [{ "type" => "CVSS_V3", "score" => "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H" }],
+      "references" => [{ "type" => "ADVISORY", "url" => "https://bugs.debian.org/778412" }],
+    }
+
+    record = Brew::Vulns::OsvExport.record_for(nvi_formula, "CVE-2015-2305", upstream: upstream, now: NOW)
+
+    assert_equal "Integer overflow in regcomp", record[:summary]
+    assert_equal "Long description.", record[:details]
+    assert_equal ["CVE-2015-2305", "GHSA-aaaa-bbbb-cccc"], record[:upstream]
+    assert_equal upstream["severity"], record[:severity]
+    assert_equal upstream["references"], record[:references]
+  end
+
+  def test_full_version_without_revision
+    formula = Brew::Vulns::Formula.new("name" => "x", "versions" => { "stable" => "1.0" }, "revision" => 0)
+
+    assert_equal "1.0", formula.full_version
+
+    record = Brew::Vulns::OsvExport.record_for(formula, "CVE-2024-1", now: NOW)
+
+    assert_equal({ fixed: "1.0" }, record[:affected].first[:ranges].first[:events][1])
+  end
+
+  def test_run_writes_one_file_per_formula_cve_pair
+    libqt = Brew::Vulns::Formula.new(
+      "name"     => "libquicktime",
+      "versions" => { "stable" => "1.2.4" },
+      "revision" => 5,
+      "patches"  => [
+        {
+          "url"      => "https://deb.debian.org/.../libquicktime_1.2.4-12.debian.tar.xz",
+          "resolves" => [
+            { "type" => "security", "id" => "CVE-2016-2399" },
+            { "type" => "security", "id" => "CVE-2017-9122" },
+          ],
+        },
+      ],
+    )
+
+    client = Object.new
+    def client.get_vulnerability(_id) = nil
+
+    Dir.mktmpdir do |dir|
+      written = Brew::Vulns::OsvExport.run([nvi_formula, libqt], dir, client: client, now: NOW)
+
+      assert_equal 3, written.size
+
+      filenames = written.map { |p| File.basename(p) }.sort
+      expected = [
+        "HOMEBREW-libquicktime-CVE-2016-2399.json",
+        "HOMEBREW-libquicktime-CVE-2017-9122.json",
+        "HOMEBREW-nvi-CVE-2015-2305.json",
+      ]
+
+      assert_equal expected, filenames
+
+      written.each do |p|
+        assert File.exist?(p)
+        record = JSON.parse(File.read(p))
+
+        assert_equal "Homebrew", record["affected"][0]["package"]["ecosystem"]
+      end
+    end
+  end
+
+  def test_run_survives_upstream_fetch_failure
+    client = Object.new
+    def client.get_vulnerability(_id) = raise Brew::Vulns::OsvClient::Error, "boom"
+
+    Dir.mktmpdir do |dir|
+      written = Brew::Vulns::OsvExport.run([nvi_formula], dir, client: client, now: NOW)
+
+      assert_equal 1, written.size
+
+      record = JSON.parse(File.read(written.first))
+
+      assert_equal ["CVE-2015-2305"], record["upstream"]
+      refute record.key?("summary")
+    end
+  end
+end


### PR DESCRIPTION
Prototype of the Homebrew-ecosystem OSV feed floated in https://github.com/orgs/Homebrew/discussions/6869 and #95. `brew vulns --osv-export DIR` walks `patches[].resolves` across homebrew-core and writes one OSV 1.7.3 record per (formula, CVE) to `DIR`.

Against current homebrew-core it emits 26 records across `glibc`, `libquicktime`, `lrzsz`, `unzip`, `zip`. Sample (`BREW-lrzsz-CVE-2018-10195.json`):

```json
{
  "schema_version": "1.7.3",
  "id": "BREW-lrzsz-CVE-2018-10195",
  "modified": "2026-06-28T20:13:40Z",
  "upstream": ["CVE-2018-10195"],
  "affected": [{
    "package": {"ecosystem": "Homebrew", "name": "lrzsz", "purl": "pkg:brew/lrzsz"},
    "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "0.12.20_1"}]}],
    "ecosystem_specific": {
      "fix": "patch",
      "patches": [{"url": "https://raw.githubusercontent.com/macports/macports-ports/2319730/comms/lrzsz/files/patch-CVE-2018-10195.diff"}]
    }
  }],
  "details": "lrzsz before version 0.12.21rc can leak information to the receiving side due to an incorrect length check in the function zsdata that causes a size_t to wrap around.",
  "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H"}],
  "references": [...]
}
```

Marked experimental. Known approximation: `fixed` is the current `version_revision`, not the revision that introduced the patch; tightening that needs `git log` on homebrew-core. Open questions for the feed itself (id namespace, version comparator, whether to also emit unpatched findings) are in the #95 thread.

