### PR TITLE
Fix clone directory name in development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ See [examples/](examples/) for workflows that check changed formulae on tap pull
 
 ```bash
 git clone https://github.com/Homebrew/homebrew-brew-vulns
-cd brew-vulns
+cd homebrew-brew-vulns
 bin/setup
 rake test
 ```


### PR DESCRIPTION
The repo was renamed to `homebrew-brew-vulns` when it moved to the Homebrew org; `git clone` creates a directory matching the repo name.