### PR TITLE
Percent-encode @ in pkg:brew purls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Query OSV for formulae whose source is not on GitHub/GitLab/Codeberg by falling back to the formula's `head` git URL, a `tag:`-style stable git URL, or a forge URL in `homepage`, with the bare formula version. Removes the forge whitelist; any formula with a derivable git repository URL is now sent in the batch query
+- CycloneDX output: percent-encode `@` in `pkg:brew/` purls so versioned formula names like `glibc@2.13` are not misparsed as `name@version`
 
 ## [0.4.0] - 2026-06-28
 

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -213,7 +213,7 @@ module Brew
             type:    "library",
             name:    formula.name,
             version: formula.version,
-            purl:    "pkg:brew/#{formula.name}@#{formula.version}",
+            purl:    formula.purl,
           }
           pedigree = formula.cyclonedx_pedigree
           component[:pedigree] = pedigree if pedigree
@@ -255,7 +255,7 @@ module Brew
           source:      { name: "OSV", url: "https://osv.dev" },
           ratings:     [{ severity: vuln.severity_display&.downcase }],
           description: vuln.summary,
-          affects:     [{ ref: "pkg:brew/#{formula.name}@#{formula.version}" }],
+          affects:     [{ ref: formula.purl }],
         }
       end
 

--- a/lib/brew/vulns/formula.rb
+++ b/lib/brew/vulns/formula.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "open3"
+require "purl"
 
 module Brew
   module Vulns
@@ -17,6 +18,14 @@ module Brew
         @homepage = data["homepage"]
         @dependencies = data["dependencies"] || []
         @patches = data["patches"] || []
+      end
+
+      # Package URL for this formula. Uses the `purl` gem so that special
+      # characters in the formula name (notably `@` in versioned formulae like
+      # `glibc@2.13`) are percent-encoded; otherwise the `@` would be parsed as
+      # the version separator.
+      def purl(with_version: true)
+        Purl::PackageURL.new(type: "brew", name: name, version: with_version ? version : nil).to_s
       end
 
       # CVE/GHSA identifiers declared as resolved by this formula's patches.

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -1027,6 +1027,27 @@ class TestCLI < Minitest::Test
     assert sbom["vulnerabilities"].any? { |v| v["id"] == "CVE-2024-1234" }
   end
 
+  def test_cyclonedx_output_encodes_at_in_formula_name_purls
+    glibc_213 = Brew::Vulns::Formula.new(
+      "name"     => "glibc@2.13",
+      "versions" => { "stable" => "2.13" },
+      "urls"     => { "stable" => { "url" => "https://github.com/example/glibc/archive/refs/tags/v2.13.tar.gz" } },
+    )
+
+    stub_request(:post, "https://api.osv.dev/v1/querybatch")
+      .to_return(status: 200, body: { results: [{ vulns: [{ "id" => "CVE-2024-2961" }] }] }.to_json)
+    stub_request(:get, "https://api.osv.dev/v1/vulns/CVE-2024-2961")
+      .to_return(status: 200, body: { "id" => "CVE-2024-2961" }.to_json)
+
+    output = Brew::Vulns::Formula.stub :load_installed, [glibc_213] do
+      capture_stdout { Brew::Vulns::CLI.run(["--cyclonedx"]) }
+    end
+    sbom = JSON.parse(output)
+
+    assert_equal "pkg:brew/glibc%402.13@2.13", sbom["components"][0]["purl"]
+    assert_equal "pkg:brew/glibc%402.13@2.13", sbom["vulnerabilities"][0]["affects"][0]["ref"]
+  end
+
   def test_cyclonedx_output_includes_vulnerability_details
     formulae = [Brew::Vulns::Formula.new(@vim_data)]
 

--- a/test/brew/test_formula.rb
+++ b/test/brew/test_formula.rb
@@ -221,6 +221,19 @@ class TestFormula < Minitest::Test
     assert_nil formula.to_osv_query
   end
 
+  def test_purl_encodes_at_in_versioned_formula_names
+    formula = Brew::Vulns::Formula.new("name" => "glibc@2.13", "versions" => { "stable" => "2.13_1" })
+
+    assert_equal "pkg:brew/glibc%402.13@2.13_1", formula.purl
+    assert_equal "pkg:brew/glibc%402.13", formula.purl(with_version: false)
+  end
+
+  def test_purl_for_plain_formula_name
+    formula = Brew::Vulns::Formula.new("name" => "vim", "versions" => { "stable" => "9.1.0" })
+
+    assert_equal "pkg:brew/vim@9.1.0", formula.purl
+  end
+
   def test_resolved_vulnerability_ids_extracts_security_ids_across_patches
     data = {
       "name"    => "libquicktime",


### PR DESCRIPTION
Versioned formula names like `glibc@2.13` contain `@`, which is the purl name/version separator; emitting `pkg:brew/glibc@2.13@2.13` misparses. Build purls via the `purl` gem so the name component is encoded as `glibc%402.13`, matching the proposed `brew` type definition in package-url/purl-spec#796.

Adds `Formula#purl` and uses it for both the CycloneDX component purl and `vulnerabilities[].affects[].ref`.