### PR TITLE
Force IPv4 on the final OSV retry and add --ipv4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Query OSV for formulae whose source is not on GitHub/GitLab/Codeberg by falling back to the formula's `head` git URL, a `tag:`-style stable git URL, or a forge URL in `homepage`, with the bare formula version. Removes the forge whitelist; any formula with a derivable git repository URL is now sent in the batch query
 - CycloneDX output: percent-encode `@` in `pkg:brew/` purls so versioned formula names like `glibc@2.13` are not misparsed as `name@version`
 - Add `--osv-export DIR` (experimental) to write OSV-schema records under a `Homebrew` ecosystem for every CVE listed in a formula's `patches[].resolves`. Each record marks the formula as fixed at the currently shipped version+revision and carries the resolving patch detail in `ecosystem_specific`. Intended as the seed for a published Homebrew advisory feed.
+- Retry the final OSV API attempt over IPv4 (via `Net::HTTP#ipaddr=`) when earlier attempts time out or fail to connect, to work around IPv6 paths that complete the TCP/TLS handshake but then drop data. Add `--ipv4` to force IPv4 from the first attempt.
 
 ## [0.4.0] - 2026-06-28
 

--- a/lib/brew/vulns/cli.rb
+++ b/lib/brew/vulns/cli.rb
@@ -29,6 +29,7 @@ module Brew
         @min_severity = parse_severity(args)
         @brewfile = parse_brewfile_path(args)
         @osv_export_dir = parse_osv_export_dir(args)
+        @force_ipv4 = args.include?("--ipv4")
       end
 
       def parse_formula_names(args)
@@ -178,7 +179,7 @@ module Brew
       end
 
       def scan_vulnerabilities(formulae)
-        client = OsvClient.new
+        client = OsvClient.new(force_ipv4: @force_ipv4)
         queries = formulae.map(&:to_osv_query).compact
 
         vuln_results = client.query_batch(queries)
@@ -469,6 +470,7 @@ module Brew
             --osv-export DIR     Write OSV-schema records for patch-resolved CVEs to DIR (experimental)
             -m, --max-summary N  Truncate summaries to N characters (default: 60, 0 for no limit)
             -s, --severity LEVEL Only show vulnerabilities at or above LEVEL (low, medium, high, critical)
+            --ipv4               Connect to api.osv.dev over IPv4 only
             -h, --help           Show this help message
 
           Examples:

--- a/lib/brew/vulns/osv_client.rb
+++ b/lib/brew/vulns/osv_client.rb
@@ -3,6 +3,7 @@
 require "net/http"
 require "json"
 require "uri"
+require "socket"
 require "brew/vulns/version"
 
 module Brew
@@ -19,6 +20,10 @@ module Brew
       class ApiError < Error; end
 
       USER_AGENT = "brew-vulns/#{Brew::Vulns::VERSION} (+https://github.com/Homebrew/homebrew-brew-vulns)"
+
+      def initialize(force_ipv4: false)
+        @force_ipv4 = force_ipv4
+      end
 
       def query(repo_url:, version:)
         payload = {
@@ -86,6 +91,7 @@ module Brew
 
       def execute_request(uri, request)
         attempts = 0
+        ipv4_addr = resolve_ipv4(uri.host) if @force_ipv4
 
         begin
           attempts += 1
@@ -94,6 +100,7 @@ module Brew
           http.verify_mode = OpenSSL::SSL::VERIFY_PEER
           http.open_timeout = OPEN_TIMEOUT
           http.read_timeout = READ_TIMEOUT
+          http.ipaddr = ipv4_addr if ipv4_addr
 
           response = http.request(request)
 
@@ -107,12 +114,14 @@ module Brew
           raise ApiError, "Invalid JSON response from OSV API: #{e.message}"
         rescue Net::OpenTimeout, Net::ReadTimeout => e
           if attempts < MAX_RETRIES
+            ipv4_addr ||= resolve_ipv4(uri.host) if attempts == MAX_RETRIES - 1
             sleep RETRY_DELAY
             retry
           end
           raise ApiError, "OSV API timeout after #{attempts} attempts: #{e.message}"
         rescue SocketError, Errno::ECONNREFUSED => e
           if attempts < MAX_RETRIES
+            ipv4_addr ||= resolve_ipv4(uri.host) if attempts == MAX_RETRIES - 1
             sleep RETRY_DELAY
             retry
           end
@@ -120,6 +129,15 @@ module Brew
         rescue OpenSSL::SSL::SSLError => e
           raise ApiError, "OSV API SSL error: #{e.message}"
         end
+      end
+
+      # Resolve the first IPv4 address for `host`, for use with Net::HTTP#ipaddr=
+      # to bypass a misbehaving IPv6 path. Returns nil (so the caller falls back
+      # to default resolution) if no A record is found or DNS fails.
+      def resolve_ipv4(host)
+        Addrinfo.getaddrinfo(host, nil, Socket::AF_INET, Socket::SOCK_STREAM).first&.ip_address
+      rescue SocketError
+        nil
       end
 
       MAX_PAGES = 100

--- a/test/brew/test_cli.rb
+++ b/test/brew/test_cli.rb
@@ -144,6 +144,35 @@ class TestCLI < Minitest::Test
     end
   end
 
+  def test_ipv4_flag_passes_force_ipv4_to_client
+    captured = nil
+    fake_client = Object.new
+    fake_client.define_singleton_method(:query_batch) { |_| [] }
+
+    Brew::Vulns::Formula.stub :load_installed, [Brew::Vulns::Formula.new(@vim_data)] do
+      Brew::Vulns::OsvClient.stub :new, ->(**opts) { captured = opts; fake_client } do
+        result = Brew::Vulns::CLI.run(["--ipv4"])
+        assert_equal 0, result
+      end
+    end
+
+    assert_equal({ force_ipv4: true }, captured)
+  end
+
+  def test_no_ipv4_flag_passes_force_ipv4_false
+    captured = nil
+    fake_client = Object.new
+    fake_client.define_singleton_method(:query_batch) { |_| [] }
+
+    Brew::Vulns::Formula.stub :load_installed, [Brew::Vulns::Formula.new(@vim_data)] do
+      Brew::Vulns::OsvClient.stub :new, ->(**opts) { captured = opts; fake_client } do
+        Brew::Vulns::CLI.run([])
+      end
+    end
+
+    assert_equal({ force_ipv4: false }, captured)
+  end
+
   def test_osv_export_flag_runs_over_all_formulae_by_default
     libqt = Brew::Vulns::Formula.new(@libquicktime_data)
     vim = Brew::Vulns::Formula.new(@vim_data)

--- a/test/brew/test_osv_client.rb
+++ b/test/brew/test_osv_client.rb
@@ -8,6 +8,20 @@ class TestOsvClient < Minitest::Test
   def setup
     super
     @client = Brew::Vulns::OsvClient.new
+    stub_resolve_ipv4(@client)
+  end
+
+  # Replace resolve_ipv4 on `client` so retry tests don't perform real DNS
+  # lookups, and record each call so tests can assert on when the IPv4
+  # fallback is triggered. Also no-ops sleep so retry tests run instantly.
+  def stub_resolve_ipv4(client, returns: nil)
+    @resolve_calls = []
+    calls = @resolve_calls
+    client.define_singleton_method(:resolve_ipv4) do |host|
+      calls << host
+      returns
+    end
+    client.define_singleton_method(:sleep) { |_| }
   end
 
   def test_query_returns_vulnerabilities
@@ -198,5 +212,81 @@ class TestOsvClient < Minitest::Test
     vulns = @client.query(repo_url: "https://github.com/test/repo", version: "v1.0.0")
 
     assert_equal [], vulns
+  end
+
+  def test_resolve_ipv4_returns_first_a_record
+    client = Brew::Vulns::OsvClient.new
+    addr = Addrinfo.ip("93.184.216.34")
+
+    Addrinfo.stub :getaddrinfo, [addr] do
+      assert_equal "93.184.216.34", client.resolve_ipv4("api.osv.dev")
+    end
+  end
+
+  def test_resolve_ipv4_returns_nil_on_dns_failure
+    client = Brew::Vulns::OsvClient.new
+
+    Addrinfo.stub :getaddrinfo, ->(*) { raise SocketError, "getaddrinfo: nodename nor servname provided" } do
+      assert_nil client.resolve_ipv4("api.osv.dev")
+    end
+  end
+
+  def test_force_ipv4_resolves_before_first_request
+    client = Brew::Vulns::OsvClient.new(force_ipv4: true)
+    stub_resolve_ipv4(client, returns: "93.184.216.34")
+
+    stub_request(:post, "https://api.osv.dev/v1/query")
+      .to_return(status: 200, body: { vulns: [] }.to_json)
+
+    client.query(repo_url: "https://github.com/test/repo", version: "v1.0.0")
+
+    assert_equal ["api.osv.dev"], @resolve_calls
+  end
+
+  def test_timeout_forces_ipv4_on_final_retry
+    stub_request(:post, "https://api.osv.dev/v1/query")
+      .to_timeout.then
+      .to_timeout.then
+      .to_return(status: 200, body: { vulns: [{ id: "CVE-2024-1234" }] }.to_json)
+
+    vulns = @client.query(repo_url: "https://github.com/test/repo", version: "v1.0.0")
+
+    assert_equal 1, vulns.size
+    assert_equal ["api.osv.dev"], @resolve_calls
+  end
+
+  def test_single_timeout_does_not_force_ipv4
+    stub_request(:post, "https://api.osv.dev/v1/query")
+      .to_timeout.then
+      .to_return(status: 200, body: { vulns: [] }.to_json)
+
+    @client.query(repo_url: "https://github.com/test/repo", version: "v1.0.0")
+
+    assert_empty @resolve_calls
+  end
+
+  def test_connection_error_forces_ipv4_on_final_retry
+    stub_request(:post, "https://api.osv.dev/v1/query")
+      .to_raise(Errno::ECONNREFUSED).then
+      .to_raise(Errno::ECONNREFUSED).then
+      .to_return(status: 200, body: { vulns: [] }.to_json)
+
+    @client.query(repo_url: "https://github.com/test/repo", version: "v1.0.0")
+
+    assert_equal ["api.osv.dev"], @resolve_calls
+  end
+
+  def test_force_ipv4_does_not_re_resolve_on_retry
+    client = Brew::Vulns::OsvClient.new(force_ipv4: true)
+    stub_resolve_ipv4(client, returns: "93.184.216.34")
+
+    stub_request(:post, "https://api.osv.dev/v1/query")
+      .to_timeout.then
+      .to_timeout.then
+      .to_return(status: 200, body: { vulns: [] }.to_json)
+
+    client.query(repo_url: "https://github.com/test/repo", version: "v1.0.0")
+
+    assert_equal ["api.osv.dev"], @resolve_calls
   end
 end


### PR DESCRIPTION
The reported `Net::ReadTimeout` in #2 happens on a single-package batch query, so it isn't payload size. The connection and TLS handshake succeed, then no response bytes arrive; `osv-scanner` (Go) works on the same machine. That pattern matches an IPv6 path that connects but then drops larger packets, which Ruby's connect-time fast-fallback won't catch because the connect succeeded.

This resolves the A record for `api.osv.dev` and pins `Net::HTTP#ipaddr` to it on the final retry after a timeout or connection error, so users hit by this recover transparently. `--ipv4` forces it from the first attempt, which also gives the reporter a way to confirm the diagnosis.

`resolve_ipv4` returns nil on DNS failure so behaviour falls back to the current default.

Side effect: stubbing `sleep` on the test client collapses the existing retry tests, so the suite drops from ~6s to ~0.1s.

Refs #2