### PR TITLE
workflows: pin Homebrew/actions to 2026.07.10.1

### DIFF
--- a/examples/pr-vuln-check.yml
+++ b/examples/pr-vuln-check.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 
       - name: Install brew-vulns
         run: brew install homebrew/brew-vulns/brew-vulns

--- a/examples/scan-all.yml
+++ b/examples/scan-all.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 
       - name: Install brew-vulns
         run: brew install homebrew/brew-vulns/brew-vulns


### PR DESCRIPTION
Pin `Homebrew/actions` references to the immutable `2026.07.10.1` release using its full commit SHA and version comment.

This removes mutable `@main` dependencies while allowing Dependabot to track future releases.