### PR TITLE
Deprecate in favour of built-in brew vulns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Deprecate in favour of the built-in `brew vulns` command shipped in Homebrew (see [Homebrew/brew#23080](https://github.com/Homebrew/brew/pull/23080)). A deprecation notice is now printed to stderr on every run and after `gem install`. The formula is marked deprecated. This tap and gem will be archived after one release cycle.
 - Query OSV for formulae whose source is not on GitHub/GitLab/Codeberg by falling back to the formula's `head` git URL, a `tag:`-style stable git URL, or a forge URL in `homepage`, with the bare formula version. Removes the forge whitelist; any formula with a derivable git repository URL is now sent in the batch query
 - CycloneDX output: percent-encode `@` in `pkg:brew/` purls so versioned formula names like `glibc@2.13` are not misparsed as `name@version`
 - Add `--osv-export DIR` (experimental) to write OSV-schema records under a `Homebrew` ecosystem for every CVE listed in a formula's `patches[].resolves`. Each record marks the formula as fixed at the currently shipped version+revision and carries the resolving patch detail in `ecosystem_specific`. Intended as the seed for a published Homebrew advisory feed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [Unreleased]
+## [0.5.0] - 2026-07-14
 
-- Deprecate in favour of the built-in `brew vulns` command shipped in Homebrew (see [Homebrew/brew#23080](https://github.com/Homebrew/brew/pull/23080)). A deprecation notice is now printed to stderr on every run and after `gem install`. The formula is marked deprecated. This tap and gem will be archived after one release cycle.
+- Deprecate in favour of the built-in `brew vulns` command shipped in Homebrew 6.0.11 (see [Homebrew/brew#23080](https://github.com/Homebrew/brew/pull/23080)). A deprecation notice is now printed to stderr on every run and after `gem install`. The formula is marked deprecated. This tap and gem will be archived after one release cycle.
 - Query OSV for formulae whose source is not on GitHub/GitLab/Codeberg by falling back to the formula's `head` git URL, a `tag:`-style stable git URL, or a forge URL in `homepage`, with the bare formula version. Removes the forge whitelist; any formula with a derivable git repository URL is now sent in the batch query
 - CycloneDX output: percent-encode `@` in `pkg:brew/` purls so versioned formula names like `glibc@2.13` are not misparsed as `name@version`
 - Add `--osv-export DIR` (experimental) to write OSV-schema records under a `Homebrew` ecosystem for every CVE listed in a formula's `patches[].resolves`. Each record marks the formula as fixed at the currently shipped version+revision and carries the resolving patch detail in `ecosystem_specific`. Intended as the seed for a published Homebrew advisory feed.

--- a/Formula/brew-vulns.rb
+++ b/Formula/brew-vulns.rb
@@ -1,9 +1,11 @@
 class BrewVulns < Formula
   desc "Check Homebrew packages for known vulnerabilities via osv.dev"
   homepage "https://github.com/Homebrew/homebrew-brew-vulns"
-  url "https://github.com/Homebrew/homebrew-brew-vulns/archive/refs/tags/v0.4.0.tar.gz"
-  sha256 "a5b03ef79d9d97a207bdeb727ce1b5bd0fc8860543005a45336c87bd973dd1ec"
+  url "https://github.com/Homebrew/homebrew-brew-vulns/archive/refs/tags/v0.5.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   license "MIT"
+
+  deprecate! date: "2026-07-13", because: "is now built into Homebrew as `brew vulns`"
 
   depends_on "ruby"
 
@@ -17,6 +19,14 @@ class BrewVulns < Formula
     system "gem", "install", "--no-document", "brew-vulns-#{version}.gem"
     bin.install libexec/"bin/brew-vulns"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV.fetch("GEM_HOME", nil))
+  end
+
+  def caveats
+    <<~EOS
+      `brew vulns` is now a built-in Homebrew command. Run `brew update` and
+      use `brew vulns` directly, then `brew uninstall brew-vulns` and
+      `brew untap homebrew/brew-vulns`.
+    EOS
   end
 
   test do

--- a/Formula/brew-vulns.rb
+++ b/Formula/brew-vulns.rb
@@ -5,7 +5,7 @@ class BrewVulns < Formula
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   license "MIT"
 
-  deprecate! date: "2026-07-13", because: "is now built into Homebrew as `brew vulns`"
+  deprecate! date: "2026-07-14", because: "is now built into Homebrew as `brew vulns`"
 
   depends_on "ruby"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    brew-vulns (0.4.0)
+    brew-vulns (0.5.0)
       cvss-suite (~> 4.1)
       purl (~> 1.6)
       sarif-ruby (~> 0.1, >= 0.1.1)
@@ -96,7 +96,7 @@ DEPENDENCIES
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
-  brew-vulns (0.4.0)
+  brew-vulns (0.5.0)
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   cvss-suite (4.1.4) sha256=2a62cfb5f14a353be0a7a61c14762901214bd1e6fcbdeab5f0161a6ffdd1d4af
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 >
 > - `--all` is dropped; with no arguments the built-in command scans every trusted formula (or just installed formulae if tap trust is disabled)
 > - `-b` short flag is dropped; use `--brewfile`
-> - `--sarif`, `--cyclonedx`, `--osv-export` and `--ipv4` are not available (SARIF and CycloneDX are planned as follow-ups)
+> - `--sarif`, `--cyclonedx` and `--ipv4` are not available (SARIF and CycloneDX are planned as follow-ups)
+> - `--osv-export` moved to `brew generate-vulns-advisories` ([Homebrew/brew#23106](https://github.com/Homebrew/brew/pull/23106)); its output lives at [Homebrew/homebrew-advisory-database](https://github.com/Homebrew/homebrew-advisory-database)
 > - Errors no longer exit with code `2`; brew's standard error handling applies. Exit `0` (clean) and `1` (vulnerabilities found) are unchanged.
 >
 > To migrate: `brew uninstall brew-vulns && brew untap homebrew/brew-vulns` (or `gem uninstall brew-vulns`).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # brew-vulns
 
+> [!WARNING]
+> **Deprecated.** `brew vulns` is now a built-in Homebrew command as of Homebrew X.Y.Z. Run `brew update` and use `brew vulns` directly; this tap and gem are no longer needed and will be archived. See [Homebrew/brew#23080](https://github.com/Homebrew/brew/pull/23080).
+>
+> Interface changes in the built-in command:
+>
+> - `--all` is now `--eval-all` (or set `HOMEBREW_EVAL_ALL=1`)
+> - `-b` short flag is dropped; use `--brewfile`
+> - `--sarif`, `--cyclonedx`, `--osv-export` and `--ipv4` are not available (SARIF and CycloneDX are planned as follow-ups)
+> - Errors no longer exit with code `2`; brew's standard error handling applies. Exit `0` (clean) and `1` (vulnerabilities found) are unchanged.
+>
+> To migrate: `brew uninstall brew-vulns && brew untap homebrew/brew-vulns` (or `gem uninstall brew-vulns`).
+
 A Homebrew subcommand that checks installed packages for known vulnerabilities using the [OSV.dev](https://osv.dev) database.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # brew-vulns
 
 > [!WARNING]
-> **Deprecated.** `brew vulns` is now a built-in Homebrew command as of Homebrew X.Y.Z. Run `brew update` and use `brew vulns` directly; this tap and gem are no longer needed and will be archived. See [Homebrew/brew#23080](https://github.com/Homebrew/brew/pull/23080).
+> **Deprecated.** `brew vulns` is now a built-in Homebrew command as of Homebrew 6.0.11. Run `brew update` and use `brew vulns` directly; this tap and gem are no longer needed and will be archived. See [Homebrew/brew#23080](https://github.com/Homebrew/brew/pull/23080).
 >
 > Interface changes in the built-in command:
 >

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > - `--all` is dropped; with no arguments the built-in command scans every trusted formula (or just installed formulae if tap trust is disabled)
 > - `-b` short flag is dropped; use `--brewfile`
 > - `--sarif`, `--cyclonedx` and `--ipv4` are not available (SARIF and CycloneDX are planned as follow-ups)
-> - `--osv-export` moved to `brew generate-vulns-advisories` ([Homebrew/brew#23106](https://github.com/Homebrew/brew/pull/23106)); its output lives at [Homebrew/homebrew-advisory-database](https://github.com/Homebrew/homebrew-advisory-database)
+> - `--osv-export` moved to `brew generate-vulns-advisories` ([Homebrew/brew#23106](https://github.com/Homebrew/brew/pull/23106)); its output lives at [Homebrew/advisory-database](https://github.com/Homebrew/advisory-database)
 > - Errors no longer exit with code `2`; brew's standard error handling applies. Exit `0` (clean) and `1` (vulnerabilities found) are unchanged.
 >
 > To migrate: `brew uninstall brew-vulns && brew untap homebrew/brew-vulns` (or `gem uninstall brew-vulns`).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 >
 > Interface changes in the built-in command:
 >
-> - `--all` is now `--eval-all` (or set `HOMEBREW_EVAL_ALL=1`)
+> - `--all` is dropped; with no arguments the built-in command scans every trusted formula (or just installed formulae if tap trust is disabled)
 > - `-b` short flag is dropped; use `--brewfile`
 > - `--sarif`, `--cyclonedx`, `--osv-export` and `--ipv4` are not available (SARIF and CycloneDX are planned as follow-ups)
 > - Errors no longer exit with code `2`; brew's standard error handling applies. Exit `0` (clean) and `1` (vulnerabilities found) are unchanged.

--- a/brew-vulns.gemspec
+++ b/brew-vulns.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
+  spec.post_install_message = Brew::Vulns::DEPRECATION_MESSAGE
+
   gemspec = File.basename(__FILE__)
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|

--- a/exe/brew-vulns
+++ b/exe/brew-vulns
@@ -3,4 +3,6 @@
 
 require "brew/vulns"
 
+warn Brew::Vulns::DEPRECATION_MESSAGE
+
 exit Brew::Vulns::CLI.run(ARGV)

--- a/lib/brew/vulns/version.rb
+++ b/lib/brew/vulns/version.rb
@@ -2,6 +2,13 @@
 
 module Brew
   module Vulns
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
+
+    DEPRECATION_MESSAGE = <<~MSG.freeze
+      brew-vulns is deprecated: `brew vulns` is now built into Homebrew.
+      Run `brew update` and use `brew vulns` directly, then remove this
+      package with `brew uninstall brew-vulns` or `gem uninstall brew-vulns`.
+      See https://github.com/Homebrew/brew/pull/23080 for details.
+    MSG
   end
 end


### PR DESCRIPTION
`brew vulns` has been upstreamed into Homebrew itself (Homebrew/brew#23080, shipped in Homebrew 6.0.11; tracking in #111). This adds the deprecation layer pointing users at the built-in command.

- README: warning banner at the top listing the interface changes (`--all` dropped, `-b` dropped, `--sarif`/`--cyclonedx`/`--ipv4` not available, `--osv-export` moved to `brew generate-vulns-advisories` feeding [Homebrew/advisory-database](https://github.com/Homebrew/advisory-database), exit code 2 no longer used) and migration steps
- `exe/brew-vulns`: prints a deprecation notice to stderr on every run (stdout unchanged so `--json`/`--sarif` consumers are unaffected)
- `brew-vulns.gemspec`: `post_install_message` with the same notice
- `Formula/brew-vulns.rb`: `deprecate!` and `caveats` pointing at the built-in command
- Version bumped to 0.5.0 with a CHANGELOG entry

The message text lives in one place (`Brew::Vulns::DEPRECATION_MESSAGE`) and is reused by the exe and gemspec.

- [x] Replace `Homebrew X.Y.Z` in README.md with the actual release (6.0.11)
- [x] Update `deprecate!` date in `Formula/brew-vulns.rb`
- [x] Cut the `[Unreleased]` CHANGELOG section to `[0.5.0]` with a date
- [ ] After merge: tag v0.5.0, then a follow-up commit filling the real `sha256` in `Formula/brew-vulns.rb` (matching the 0.4.0 release flow)
- [ ] After merge: `gem push` 0.5.0 to rubygems.org